### PR TITLE
Feature/foreach eval basic lib

### DIFF
--- a/src/stdlib/list.rs
+++ b/src/stdlib/list.rs
@@ -59,15 +59,20 @@ pub fn build_list(args: &mut Iterator<Item=&Value>,
     Ok(Value::new_list(v.take().unwrap()))
 }
 
+
 pub fn foreach(args: &mut Iterator<Item=&Value>,
               env: &Env,
               eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
     let list = match args.next() {
-        Some(&Value::List(ref l)) => l.clone(),
-        Some(v) => return Err(AresError::UnexpectedType{
-            value: v.clone(),
-            expected: "List".into()
-        }),
+        Some(v) => match try!(eval(v, env)) {
+            Value::List(ref l) => l.clone(),
+            v => {
+                return Err(AresError::UnexpectedType{
+                    value: v.clone(),
+                    expected: "List".into()
+                })
+            }
+        },
         None => return Err(AresError::UnexpectedArity {
             found: 0,
             expected: "exactly 2".into()
@@ -75,7 +80,7 @@ pub fn foreach(args: &mut Iterator<Item=&Value>,
     };
 
     let func = match args.next() {
-        Some(f) => f.clone(),
+        Some(f) => try!(eval(f, env)).clone(),
         None => return Err(AresError::UnexpectedArity {
             found: 1,
             expected: "exactly 2".into()
@@ -114,3 +119,5 @@ pub static FILTER: &'static str = "(lambda (list fn)
                 (if (fn element)
                     (push element)
                     false))))))";
+
+pub static LIST: &'static str = "(lambda list list)";

--- a/src/stdlib/list.rs
+++ b/src/stdlib/list.rs
@@ -119,5 +119,3 @@ pub static FILTER: &'static str = "(lambda (list fn)
                 (if (fn element)
                     (push element)
                     false))))))";
-
-pub static LIST: &'static str = "(lambda list list)";

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -54,7 +54,7 @@ pub fn load_all(env: &mut Environment) {
 pub fn basic_environment() -> Rc<RefCell<Environment>> {
     let mut env = Environment::new();
     load_all(&mut env);
-    let mut env = Rc::new(RefCell::new(env));
+    let env = Rc::new(RefCell::new(env));
     let define = Value::new_ident("define");
     let _ = vec![list::MAP, list::FOLD_LEFT, list::FILTER, list::LIST].iter()
         .zip(vec!["map", "foldl", "filter", "list"])

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -1,4 +1,9 @@
 use ::Environment;
+use ::Value;
+use ::eval::eval;
+use ::parse;
+use std::rc::Rc;
+use std::cell::RefCell;
 
 pub mod arithmetic;
 pub mod math;
@@ -46,6 +51,20 @@ pub fn load_all(env: &mut Environment) {
     load_types(env);
 }
 
+pub fn basic_environment() -> Rc<RefCell<Environment>> {
+    let mut env = Environment::new();
+    load_all(&mut env);
+    let mut env = Rc::new(RefCell::new(env));
+    let define = Value::new_ident("define");
+    let _ = vec![list::MAP, list::FOLD_LEFT, list::FILTER, list::LIST].iter()
+        .zip(vec!["map", "foldl", "filter", "list"])
+        .map(|(function, name)| {
+            let parsed = parse(*function).ok().expect("couldn't parse built-in code")[0].clone();
+            eval(&Value::new_list(vec![define.clone(), Value::new_ident(name), parsed]), &env).ok().expect("couldn't eval built-in code");
+        }).collect::<Vec<_>>();
+    env
+}
+
 pub fn load_logical(env: &mut Environment) {
     env.set_uneval_function("and", self::logical::and);
     env.set_uneval_function("or", self::logical::or);
@@ -62,6 +81,7 @@ pub fn load_core(env: &mut Environment) {
 
 pub fn load_list(env: &mut Environment) {
     env.set_uneval_function("build-list", self::list::build_list);
+    env.set_uneval_function("for-each", self::list::foreach);
 }
 
 pub fn load_arithmetic(env: &mut Environment) {

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -10,3 +10,14 @@ fn build_list() {
     eval_ok!("(build-list (lambda (push) (push 1)))", vec![1]);
     eval_ok!("(build-list (lambda (push) (push 1) (push 2) (push 3)))", vec![1, 2, 3]);
 }
+
+#[test]
+fn to_list() {
+    eval_ok!("(list 1 2 3)", vec![1, 2, 3]);
+}
+
+#[test]
+fn test_map() {
+    eval_ok!("(map (list 1 2 3) (lambda (x) (+ x 1)))", vec![2, 3, 4]);
+    eval_ok!("(map '(1 2 3) (lambda (x) (+ x 1)))", vec![2, 3, 4]);
+}

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -2,9 +2,6 @@ extern crate ares;
 
 use ::ares::*;
 
-use std::rc::Rc;
-use std::cell::RefCell;
-
 #[macro_export]
 macro_rules! eval_ok {
     ($prog: expr, $v: expr) => {
@@ -26,15 +23,9 @@ macro_rules! eval_err {
     }
 }
 
-fn basic_environment() -> Rc<RefCell<Environment>> {
-    let mut env = Environment::new();
-    stdlib::load_all(&mut env);
-    Rc::new(RefCell::new(env))
-}
-
 pub fn e(program: &str) -> AresResult<Value> {
+    let mut env = stdlib::basic_environment();
     let trees = parse(program).unwrap();
-    let mut env = basic_environment();
     let mut last = None;
     for tree in trees {
         last = Some(try!(eval(&tree, &mut env)))


### PR DESCRIPTION
actually load the statically-defined functions in list.rs, and change `for-each` to evaluate its arguments (otherwise e.g. `map` doesn't work). Also fixes a parsing bug revealed by one of the `map` tests.

Arguably `for-each` shouldn't be a special form but just a regular function; it seems like it's defined the way it is because that gives it access to the environment and an `eval` function passed in as an argument. AFAICT though it should be possible for the regular functions to access the environment---as functions that are defined in the interpreted language can---and to be able to call `eval`. (Or, possibly better, an `apply` that assumes its arguments are already evaluated. Note that you can't currently define this:

```scheme
(define concat (lambda lists
  (build-list (push)
    (for-each lists (lambda (list)
       (for-each list (lambda (element) (push element))))))
```

because calling `(concat '(1 2) '(3 4))` results in an attempt to evaluate `(1 2)`.