### PR TITLE
Add Context as the main API layer

### DIFF
--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -10,29 +10,19 @@ use term_painter::Color::*;
 use term_painter::ToStyle;
 
 fn main() {
-    let env = ares::Environment::new();
-    let mut env = Rc::new(RefCell::new(env));
-    ares::stdlib::load_all(&env);
+    let mut ctx = ares::Context::<()>::new();
+    let mut dummy = ();
+    let mut ctx = ctx.load(&mut dummy);
 
     let stdin = io::stdin();
     for line in stdin.lock().lines().take_while(|a| a.is_ok()).filter_map(|a| a.ok()) {
-        let trees = match ares::parse(&line) {
-            Ok(trees) => trees,
-            Err(parse_error) => {
-                println!("Parse error: {}", Red.paint(parse_error));
-                continue
+        match ctx.eval_str(&line) {
+            Ok(v) => {
+                println!("{:?}", Green.paint(v))
             }
-        };
-
-        for tree in trees {
-            match ares::eval(&tree, &mut env) {
-                Ok(v) => {
-                    println!("{:?}", Green.paint(v))
-                }
-                Err(e) => {
-                    println!("err: {:?}", Red.paint(e));
-                    break;
-                }
+            Err(e) => {
+                println!("err: {:?}", Red.paint(e));
+                break;
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,40 @@ impl <S> From<ParseError> for AresError<S> {
 use std::fmt::{Debug, Formatter, Error};
 impl <S> Debug for AresError<S> {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
-        fmt.write_str("todo lol")
+        match self {
+            &AresError::ParseError(ref pe) => write!(fmt, "ParseError({})", pe),
+            &AresError::NoProgram => write!(fmt, "NoProgram"),
+
+            &AresError::UnexpectedType{ref value, ref expected} =>
+                write!(fmt, "UnexpectedType(found {:?}, expected {})", value, expected),
+            &AresError::UnexpectedArity{ref found, ref expected} =>
+                write!(fmt, "UnexpectedArity(found {}, expected {})", found, expected),
+
+            &AresError::UnexecutableValue(ref v) =>
+                write!(fmt, "UnexecutableValue({:?})", v),
+            &AresError::ExecuteEmptyList =>
+                write!(fmt, "ExecuteEmptyList"),
+
+            &AresError::UnexpectedArgsList(ref v) =>
+                write!(fmt, "UnexpectedArgsList({:?})", v),
+
+            &AresError::IllegalConversion{ref value, ref into} =>
+                write!(fmt, "IllegalConversion(from {:?}, into {})", value, into),
+            &AresError::UndefinedName(ref name) =>
+                write!(fmt, "UndefinedName({})", name),
+            &AresError::InvalidState(ref desc) =>
+                write!(fmt, "InvalidState({})", desc),
+
+            // TODO: NoNamedSet, NoValuedSet
+            &AresError::NoNameSet => fmt.write_str("NoNameSet"),
+            &AresError::NoValueSet => fmt.write_str("NoValueSet"),
+
+            &AresError::AlreadyDefined(ref name) =>
+                write!(fmt, "AlreadyDefined({})", name),
+            &AresError::NoNameDefine => fmt.write_str("NoNameDefine"),
+            &AresError::NoValueDefine => fmt.write_str("NoValueDefine"),
+            &AresError::MultiValueDefine => fmt.write_str("MultiValueDefine"),
+
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ pub type AresResult<T> = Result<T, AresError>;
 #[derive(Debug)]
 pub enum AresError {
     ParseError(ParseError),
+    NoProgram,
 
     UnexpectedType{value: Value, expected: String},
     UnexpectedArity{found: u16, expected: String},
@@ -21,6 +22,7 @@ pub enum AresError {
     UndefinedName(String),
     InvalidState(String),
 
+    // TODO: NoNamedSet, NoValuedSet
     NoNameSet,
     NoValueSet,
 
@@ -31,3 +33,8 @@ pub enum AresError {
     MultiValueDefine,
 }
 
+impl From<ParseError> for AresError {
+    fn from(pe: ParseError) -> AresError {
+        AresError::ParseError(pe)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,21 @@
 use ::Value;
 use ::tokenizer::ParseError;
 
-pub type AresResult<T> = Result<T, AresError>;
+pub type AresResult<T, S> = Result<T, AresError<S>>;
 
-#[derive(Debug)]
-pub enum AresError {
+pub enum AresError<S> {
     ParseError(ParseError),
     NoProgram,
 
-    UnexpectedType{value: Value, expected: String},
+    UnexpectedType{value: Value<S>, expected: String},
     UnexpectedArity{found: u16, expected: String},
 
-    UnexecutableValue(Value),
+    UnexecutableValue(Value<S>),
     ExecuteEmptyList,
 
-    UnexpectedArgsList(Value),
+    UnexpectedArgsList(Value<S>),
 
-    IllegalConversion{value: Value, into: String},
+    IllegalConversion{value: Value<S>, into: String},
     UndefinedName(String),
     InvalidState(String),
 
@@ -31,8 +30,16 @@ pub enum AresError {
     MultiValueDefine,
 }
 
-impl From<ParseError> for AresError {
-    fn from(pe: ParseError) -> AresError {
+impl <S> From<ParseError> for AresError<S> {
+    fn from(pe: ParseError) -> AresError<S> {
         AresError::ParseError(pe)
+    }
+}
+
+
+use std::fmt::{Debug, Formatter, Error};
+impl <S> Debug for AresError<S> {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        fmt.write_str("todo lol")
     }
 }

--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -1,0 +1,98 @@
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+use super::{Env, eval};
+use ::{Value, AresResult, AresError, parse, stdlib, Environment};
+
+pub struct Context<T> {
+    env: Env,
+    _state: PhantomData<T>,
+}
+
+pub struct LoadedContext<'a, 'b, T: 'a + 'b> {
+    ctx: &'b mut Context<T>,
+    state: &'a mut T,
+}
+
+impl <T> Context<T> {
+    pub fn new() -> Context<T> {
+        let env = Rc::new(RefCell::new(Environment::new()));
+        stdlib::load_all(&env);
+        Context {
+            env: env,
+            _state: PhantomData,
+        }
+    }
+
+    pub fn new_empty() -> Context<T> {
+        Context {
+            env: Rc::new(RefCell::new(Environment::new())),
+            _state: PhantomData,
+        }
+    }
+
+    pub fn load<'a, 'b>(&'b mut self, state: &'a mut T) -> LoadedContext<'a, 'b, T> {
+        LoadedContext {
+            ctx: self,
+            state: state
+        }
+    }
+
+    pub fn env(&self) -> &Env {
+        &self.env
+    }
+}
+
+impl <'a, 'b,  T> LoadedContext<'a, 'b, T> {
+    pub fn eval(&mut self, program: &Value) -> AresResult<Value> {
+        eval(program, self.env())
+    }
+
+    pub fn eval_str(&mut self, program: &str) -> AresResult<Value> {
+        let trees = try!(parse(program));
+        let mut last = None;
+        for tree in trees {
+            last = Some(try!(eval(&tree, self.env())))
+        }
+        match last {
+            Some(v) => Ok(v),
+            None => Err(AresError::NoProgram)
+        }
+    }
+
+    pub fn call(&mut self, func: Value, mut args: Vec<Value>) -> AresResult<Value> {
+        for arg in args.iter_mut() {
+            if let a@&mut Value::List(_) = arg {
+                // TODO: can you get rid of this clone?
+                *a = Value::new_list(vec![Value::new_ident("quote"), a.clone()]);
+            }
+        }
+
+        let built = Value::new_list(vec![func, Value::new_list(args)]);
+        self.eval(&built)
+    }
+
+    pub fn call_global<S: AsRef<str>>(&mut self, global_fn: S, args: Vec<Value>) -> AresResult<Value> {
+        let global_fn = match self.env().borrow().get(global_fn.as_ref()) {
+            Some(f) => f,
+            None => return Err(AresError::UndefinedName(global_fn.as_ref().into()))
+        };
+
+        self.call(global_fn, args)
+    }
+}
+
+impl <'a,'b, T > Deref for LoadedContext<'a, 'b, T > {
+    type Target = Context<T>;
+    fn deref(&self) -> &Context<T> {
+        &self.ctx
+    }
+}
+
+impl <'a, 'b, T> DerefMut for LoadedContext<'a, 'b, T> {
+    fn deref_mut(&mut self) -> &mut Context<T> {
+        &mut self.ctx
+    }
+}

--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -74,7 +74,7 @@ impl <'a, 'b,  T> LoadedContext<'a, 'b, T> {
         self.eval(&built)
     }
 
-    pub fn call_global<S: AsRef<str>>(&mut self, global_fn: S, args: Vec<Value>) -> AresResult<Value> {
+    pub fn call_named<S: AsRef<str>>(&mut self, global_fn: S, args: Vec<Value>) -> AresResult<Value> {
         let global_fn = match self.env().borrow().get(global_fn.as_ref()) {
             Some(f) => f,
             None => return Err(AresError::UndefinedName(global_fn.as_ref().into()))

--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -2,59 +2,90 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
+use std::borrow::Cow;
 
 use super::{Env, eval, apply};
 use ::{Value, AresResult, AresError, parse, stdlib, Environment};
 
-pub struct Context<T> {
-    env: Env,
-    _state: PhantomData<T>,
+pub struct Context<S> {
+    env: Env<S>,
+    _state: PhantomData<S>,
 }
 
-pub struct LoadedContext<'a, 'b, T: 'a + 'b> {
-    ctx: &'b mut Context<T>,
-    state: &'a mut T,
+pub struct LoadedContext<'a, S: 'a> {
+    ctx: &'a mut Context<S>,
+    override_env: Option<Env<S>>,
+    state: &'a mut S,
 }
 
-impl <T> Context<T> {
-    pub fn new() -> Context<T> {
+impl <S: 'static> Context<S> {
+    pub fn new() -> Context<S> {
         let env = Rc::new(RefCell::new(Environment::new()));
-        stdlib::load_all(&env);
-        Context {
+        let mut ctx = Context {
             env: env,
             _state: PhantomData,
-        }
+        };
+
+        stdlib::load_all(&mut ctx);
+
+        ctx
     }
 
-    pub fn new_empty() -> Context<T> {
+    pub fn new_empty() -> Context<S> {
         Context {
             env: Rc::new(RefCell::new(Environment::new())),
             _state: PhantomData,
         }
     }
 
-    pub fn load<'a, 'b>(&'b mut self, state: &'a mut T) -> LoadedContext<'a, 'b, T> {
+    pub fn get<N: AsRef<str>>(&self, name: &N) -> Option<Value<S>> {
+        self.env.borrow_mut().get(name.as_ref())
+    }
+
+    pub fn set<N: Into<String>>(&mut self, name: N, value: Value<S>) -> Option<Value<S>> {
+        self.env.borrow_mut().insert_here(name, value)
+    }
+
+    pub fn load<'a>(&'a mut self, state: &'a mut S) -> LoadedContext<'a, S> {
         LoadedContext {
             ctx: self,
-            state: state
+            state: state,
+            override_env: None,
         }
     }
 
-    pub fn env(&self) -> &Env {
+    pub fn env(&self) -> &Env<S> {
         &self.env
     }
 }
 
-impl <'a, 'b,  T> LoadedContext<'a, 'b, T> {
-    pub fn eval(&mut self, value: &Value) -> AresResult<Value> {
-        eval(value, self.env())
+impl <'a, S> LoadedContext<'a, S> {
+    pub fn unload(self) { }
+
+    pub fn env(&self) -> &Env<S> {
+        self.override_env.as_ref().unwrap_or(&self.env)
     }
 
-    pub fn eval_str(&mut self, program: &str) -> AresResult<Value> {
+    pub fn eval(&mut self, value: &Value<S>) -> AresResult<Value<S>, S> {
+        eval(value, self)
+    }
+
+    // TODO: hide from docs
+    pub fn with_env<F, R>(&mut self, mut env: Env<S>, f: F) -> R
+    where F: FnOnce(&mut LoadedContext<'a, S>) -> R
+    {
+        use std::mem::swap;
+        swap(&mut self.env, &mut env);
+        let r = f(self);
+        swap(&mut self.env, &mut env);
+        r
+    }
+
+    pub fn eval_str(&mut self, program: &str) -> AresResult<Value<S>, S> {
         let trees = try!(parse(program));
         let mut last = None;
         for tree in trees {
-            last = Some(try!(eval(&tree, self.env())))
+            last = Some(try!(eval(&tree, self)))
         }
         match last {
             Some(v) => Ok(v),
@@ -62,11 +93,11 @@ impl <'a, 'b,  T> LoadedContext<'a, 'b, T> {
         }
     }
 
-    pub fn call(&mut self, func: &Value, mut args: &[Value]) -> AresResult<Value> {
-        apply(func, &args[..], self.env())
+    pub fn call(&mut self, func: &Value<S>, mut args: &[Value<S>]) -> AresResult<Value<S>, S> {
+        apply(func, &args[..], self)
     }
 
-    pub fn call_named<S: AsRef<str>>(&mut self, global_fn: S, args: &[Value]) -> AresResult<Value> {
+    pub fn call_named<N: AsRef<str>>(&mut self, global_fn: N, args: &[Value<S>]) -> AresResult<Value<S>, S> {
         let func = self.env.borrow().get(global_fn.as_ref());
         match func {
             Some(v) => self.call(&v, args),
@@ -75,15 +106,15 @@ impl <'a, 'b,  T> LoadedContext<'a, 'b, T> {
     }
 }
 
-impl <'a,'b, T > Deref for LoadedContext<'a, 'b, T > {
-    type Target = Context<T>;
-    fn deref(&self) -> &Context<T> {
+impl <'a, S> Deref for LoadedContext<'a, S> {
+    type Target = Context<S>;
+    fn deref(&self) -> &Context<S> {
         &self.ctx
     }
 }
 
-impl <'a, 'b, T> DerefMut for LoadedContext<'a, 'b, T> {
-    fn deref_mut(&mut self) -> &mut Context<T> {
+impl <'a, S> DerefMut for LoadedContext<'a, S> {
+    fn deref_mut(&mut self) -> &mut Context<S> {
         &mut self.ctx
     }
 }

--- a/src/eval/environment.rs
+++ b/src/eval/environment.rs
@@ -4,21 +4,21 @@ use std::cell::RefCell;
 
 use ::Value;
 
-pub type Env = Rc<RefCell<Environment>>;
-pub struct Environment {
-    parent: Option<Env>,
-    bindings: HashMap<String, Value>
+pub type Env<S> = Rc<RefCell<Environment<S>>>;
+pub struct Environment<S> {
+    parent: Option<Env<S>>,
+    bindings: HashMap<String, Value<S>>
 }
 
-impl Environment {
-    pub fn new() -> Environment {
+impl <S> Environment<S>  {
+    pub fn new() -> Environment<S> {
         Environment {
             parent: None,
             bindings: HashMap::new()
         }
     }
 
-    pub fn new_with_data(env: Env, bindings: HashMap<String, Value>) -> Env {
+    pub fn new_with_data(env: Env<S>, bindings: HashMap<String, Value<S>>) -> Env<S> {
         Rc::new(RefCell::new(Environment {
             parent: Some(env),
             bindings: bindings
@@ -33,7 +33,7 @@ impl Environment {
         self.with_value(name, |_| ()).is_some()
     }
 
-    pub fn get(&self, name: &str) -> Option<Value> {
+    pub fn get(&self, name: &str) -> Option<Value<S>> {
         if self.bindings.contains_key(name) {
             Some(self.bindings[name].clone())
         } else if let Some(ref p) = self.parent {
@@ -45,7 +45,7 @@ impl Environment {
     }
 
     pub fn with_value<F, R>(&self, name: &str, function: F) -> Option<R>
-    where F: FnOnce(&Value) -> R
+    where F: FnOnce(&Value<S>) -> R
     {
         if self.bindings.contains_key(name) {
             Some(function(&self.bindings[name]))
@@ -58,7 +58,7 @@ impl Environment {
     }
 
     pub fn with_value_mut<F, R>(&mut self, name: &str, function: F) -> Option<R>
-    where F: FnOnce(&mut Value) -> R
+    where F: FnOnce(&mut Value<S>) -> R
     {
         if self.bindings.contains_key(name) {
             Some(function(self.bindings.get_mut(name).unwrap()))
@@ -70,8 +70,8 @@ impl Environment {
         }
     }
 
-    pub fn insert_here<S: Into<String>>(&mut self, name: S, value: Value) -> Option<Value> {
-        self.bindings.insert(name.into(), value)
+    pub fn insert_here<N: Into<String>>(&mut self, name: N, values: Value<S>) -> Option<Value<S>> {
+        self.bindings.insert(name.into(), values)
     }
 }
 

--- a/src/eval/environment.rs
+++ b/src/eval/environment.rs
@@ -20,7 +20,6 @@ impl Environment {
         }
     }
 
-
     pub fn new_with_data(env: Env, bindings: HashMap<String, Value>) -> Env {
         Rc::new(RefCell::new(Environment {
             parent: Some(env),

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -63,4 +63,3 @@ pub fn eval(value: &Value, env: &Rc<RefCell<Environment>>) -> AresResult<Value> 
         }
     }
 }
-

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -6,10 +6,12 @@ use super::{Value, AresError, AresResult};
 pub use self::environment::{Env, Environment};
 pub use self::foreign_function::{ForeignFunction, FfType};
 pub use self::procedure::{Procedure, ParamBinding};
+pub use self::context::Context;
 
 mod environment;
 mod foreign_function;
 mod procedure;
+mod context;
 
 pub fn eval(value: &Value, env: &Rc<RefCell<Environment>>) -> AresResult<Value> {
     match value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(mutable_transmutes)]
-
 use std::rc::Rc;
+use std::fmt::{Debug, Formatter};
+use std::fmt::Error as FormatError;
 
 pub mod tokenizer;
 mod eval;
@@ -37,7 +38,6 @@ macro_rules! gen_from {
     }
 }
 
-#[derive(Debug)]
 pub enum Value<S> {
     List(Rc<Vec<Value<S>>>),
     String(Rc<String>),
@@ -50,6 +50,7 @@ pub enum Value<S> {
     Lambda(Procedure<S>)
 }
 
+
 impl <S> Value<S> {
     pub fn new_string<N: Into<String>>(s: N) -> Value<S> {
         Value::String(Rc::new(s.into()))
@@ -59,6 +60,12 @@ impl <S> Value<S> {
     }
     pub fn new_list(v: Vec<Value<S>>) -> Value<S> {
         Value::List(Rc::new(v))
+    }
+}
+
+impl <S> Debug for Value<S> {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), FormatError> {
+        fmt.write_str(&stdlib::types::to_string_helper(self))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod error;
 pub mod util;
 
 pub use tokenizer::parse;
-pub use eval::{Procedure, eval, ForeignFunction, Env, Environment, ParamBinding};
+pub use eval::{Procedure, eval, ForeignFunction, Env, Environment, ParamBinding, Context};
 pub use error::{AresError, AresResult};
 
 macro_rules! gen_from {

--- a/src/stdlib/arithmetic.rs
+++ b/src/stdlib/arithmetic.rs
@@ -15,7 +15,7 @@ macro_rules! gen_fold {
                 });
             }
         }
-        let res: AresResult<_> = $extr(cur);
+        let res: AresResult<_, _> = $extr(cur);
         let res = try!(res);
         Ok($var(res))
         }
@@ -25,15 +25,15 @@ macro_rules! gen_fold {
     }
 }
 
-pub fn add_ints(args: &[Value]) -> AresResult<Value> {
+pub fn add_ints<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     gen_fold!(args, 0i64, Value::Int, |acc: &mut i64, v: i64| *acc += v)
 }
 
-pub fn add_floats(args: &[Value]) -> AresResult<Value> {
+pub fn add_floats<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     gen_fold!(args, 0.0f64, Value::Float, |acc: &mut f64, v: f64| *acc += v)
 }
 
-pub fn sub_ints(args: &[Value]) -> AresResult<Value> {
+pub fn sub_ints<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     gen_fold!(args, None, Value::Int, |acc: &mut Option<(bool, i64)>, v: i64| {
         if let &mut Some((ref mut first, ref mut acc)) = acc {
             if *first {
@@ -54,7 +54,7 @@ pub fn sub_ints(args: &[Value]) -> AresResult<Value> {
     })
 }
 
-pub fn sub_floats(args: &[Value]) -> AresResult<Value> {
+pub fn sub_floats<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     gen_fold!(args, None, Value::Float, |acc: &mut Option<(bool, f64)>, v: f64| {
         if let &mut Some((ref mut first, ref mut acc)) = acc {
             if *first {
@@ -75,15 +75,15 @@ pub fn sub_floats(args: &[Value]) -> AresResult<Value> {
     })
 }
 
-pub fn mul_ints(args: &[Value]) -> AresResult<Value> {
+pub fn mul_ints<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     gen_fold!(args, 1i64, Value::Int, |acc: &mut i64, v: i64| *acc *= v)
 }
 
-pub fn mul_floats(args: &[Value]) -> AresResult<Value> {
+pub fn mul_floats<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     gen_fold!(args, 1.0f64, Value::Float, |acc: &mut f64, v: f64| *acc *= v)
 }
 
-pub fn div_ints(args: &[Value]) -> AresResult<Value> {
+pub fn div_ints<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     gen_fold!(args, None, Value::Int, |acc: &mut Option<i64>, v: i64| {
         if let &mut Some(ref mut acc) = acc {
             *acc /= v
@@ -101,13 +101,13 @@ pub fn div_ints(args: &[Value]) -> AresResult<Value> {
     })
 }
 
-pub fn div_floats(args: &[Value]) -> AresResult<Value> {
+pub fn div_floats<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     gen_fold!(args, 1.0f64, Value::Float, |acc: &mut f64, v: f64| *acc /= v)
 }
 
 
 // TODO: move this to a new strings module
-pub fn concat(args: &[Value]) -> AresResult<Value> {
+pub fn concat<S>(args: &[Value<S>]) -> AresResult<Value<S>, S> {
     let mut buffer = String::new();
     for v in args {
         if let &Value::String(ref s) = v {

--- a/src/stdlib/arithmetic.rs
+++ b/src/stdlib/arithmetic.rs
@@ -15,7 +15,9 @@ macro_rules! gen_fold {
                 });
             }
         }
-        Ok($var(try!($extr(cur))))
+        let res: AresResult<_> = $extr(cur);
+        let res = try!(res);
+        Ok($var(res))
         }
     };
     ($args: expr, $default: expr, $var: path, $op: expr) => {

--- a/src/stdlib/logical.rs
+++ b/src/stdlib/logical.rs
@@ -1,10 +1,8 @@
-use ::{Value, AresResult, Env, AresError};
+use ::{Value, AresResult, Env, AresError, LoadedContext};
 
-pub fn and(args: &[Value],
-           env: &Env,
-           eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
+pub fn and<S>(args: &[Value<S>], ctx: &mut LoadedContext<S>) -> AresResult<Value<S>, S> {
     for value in args {
-        match try!(eval(value, env)) {
+        match try!(ctx.eval(value)) {
             Value::Bool(true) => { }
             Value::Bool(false) => return Ok(Value::Bool(false)),
             other => return Err(AresError::UnexpectedType {
@@ -16,11 +14,9 @@ pub fn and(args: &[Value],
     Ok(Value::Bool(true))
 }
 
-pub fn or(args: &[Value],
-           env: &Env,
-           eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
+pub fn or<S>(args: &[Value<S>], ctx: &mut LoadedContext<S>) -> AresResult<Value<S>, S> {
     for value in args {
-        match try!(eval(value, env)) {
+        match try!(ctx.eval(value)) {
             Value::Bool(true) => return Ok(Value::Bool(true)),
             Value::Bool(false) => {},
             other => return Err(AresError::UnexpectedType {
@@ -32,13 +28,11 @@ pub fn or(args: &[Value],
     Ok(Value::Bool(false))
 }
 
-pub fn xor(args: &[Value],
-           env: &Env,
-           eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
+pub fn xor<S>(args: &[Value<S>], ctx: &mut LoadedContext<S>) -> AresResult<Value<S>, S> {
     let mut found_true = false;
     let mut found_false = false;
     for value in args {
-        match try!(eval(value, env)) {
+        match try!(ctx.eval(value)) {
             Value::Bool(true) => {
                 found_true = true;
                 if found_true && found_false {

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -9,7 +9,7 @@ macro_rules! gen_num_method {
         gen_num_method!($name, $inv, $outv, |a| a);
     };
     ($name: ident, $inv: path, $outv: path, $conv: expr) => {
-        pub fn $name(values: &[Value]) -> AresResult<Value> {
+        pub fn $name<S>(values: &[Value<S>]) -> AresResult<Value<S>, S> {
             try!(expect_arity(values, |l| l == 1, "exactly 1"));
             let value = match values.first().unwrap() {
                 &$inv(v) => $outv($conv(v.$name())),

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -1,4 +1,4 @@
-use ::{Env, free_fn, ast_fn};
+use ::{free_fn, ast_fn, Context, LoadedContext};
 
 pub mod arithmetic;
 pub mod math;
@@ -9,8 +9,8 @@ pub mod logical;
 
 pub mod util {
     use ::{AresError, AresResult};
-    pub fn expect_arity<F, S: Into<String>, T>(slice: &[T], expected: F, expect_str: S) -> AresResult<()>
-    where S: Into<String>, F: FnOnce(usize) -> bool {
+    pub fn expect_arity<F, E, T, S>(slice: &[T], expected: F, expect_str: E) -> AresResult<(), S>
+    where E: Into<String>, F: FnOnce(usize) -> bool {
         let len = slice.len();
         if expected(len) {
             Ok(())
@@ -23,135 +23,143 @@ pub mod util {
     }
 }
 
-fn eval_into<S: AsRef<str>>(src: &S, env: &Env) {
+unsafe fn load_fake<'a, T: 'static>(ctx: &'a mut Context<T>) -> LoadedContext<'a, T> {
+    use std::mem::transmute;
     use ::{eval, parse};
+
+    let dummy = ();
+    let dumb_ref: &'a mut T = unsafe { transmute(&dummy) };
+
+    ctx.load(dumb_ref)
+}
+
+fn eval_into<'a, T: 'static, S: AsRef<str>>(src: &S, ctx: &'a mut Context<T>) {
+    use std::mem::transmute;
+    use ::{eval, parse};
+
+    let mut ctx = unsafe { load_fake::<T>(ctx) };
+
     let parsed = parse(src.as_ref()).unwrap();
     for statement in &parsed {
-        eval(statement, env).unwrap();
+        ctx.eval(statement).unwrap();
     }
 }
 
-pub fn load_all(env: &Env) {
-    load_logical(env);
-    load_core(env);
-    load_list(env);
-    load_math(env);
-    load_arithmetic(env);
-    load_types(env);
+pub fn load_all<T: 'static>(ctx: &mut Context<T>) {
+    load_logical(ctx);
+    load_core(ctx);
+    load_list(ctx);
+    load_math(ctx);
+    load_arithmetic(ctx);
+    load_types(ctx);
 }
 
-pub fn load_logical(env: &Env) {
-    let mut env = env.borrow_mut();
-    env.insert_here("and", ast_fn("and", self::logical::and));
-    env.insert_here("or", ast_fn("or", self::logical::or));
-    env.insert_here("xor", ast_fn("xor", self::logical::xor));
+pub fn load_logical<T: 'static>(ctx: &mut Context<T>) {
+    ctx.set("and", ast_fn("and", self::logical::and));
+    ctx.set("or", ast_fn("or", self::logical::or));
+    ctx.set("xor", ast_fn("xor", self::logical::xor));
 }
 
-pub fn load_core(env: &Env) {
-    let mut env = env.borrow_mut();
-    env.insert_here("quote", ast_fn("quote", self::core::quote));
-    env.insert_here("if", ast_fn("if", self::core::cond));
-    env.insert_here("set", ast_fn("set", self::core::set));
-    env.insert_here("define", ast_fn("define", self::core::define));
-    env.insert_here("lambda", ast_fn("lambda", self::core::lambda));
+pub fn load_core<T: 'static>(ctx: &mut Context<T>) {
+    ctx.set("quote", free_fn("quote", self::core::quote));
+    ctx.set("if", ast_fn("if", self::core::cond));
+    ctx.set("set", ast_fn("set", self::core::set));
+    ctx.set("define", ast_fn("define", self::core::define));
+    ctx.set("lambda", ast_fn("lambda", self::core::lambda));
 }
 
-pub fn load_list(env: &Env) {
+pub fn load_list<T: 'static>(ctx: &mut Context<T>) {
     {
-        let mut env = env.borrow_mut();
-        env.insert_here("build-list", ast_fn("build-list", self::list::build_list));
-        env.insert_here("for-each", ast_fn("for-each", self::list::foreach));
+        ctx.set("build-list", ast_fn("build-list", self::list::build_list));
+        ctx.set("for-each", ast_fn("for-each", self::list::foreach));
     }
-    eval_into(&format!("(define list {})", self::list::LIST), env);
-    eval_into(&format!("(define map {})", self::list::MAP), env);
-    eval_into(&format!("(define fold-left {})", self::list::FOLD_LEFT), env);
-    eval_into(&format!("(define filter {})", self::list::FILTER), env);
-    eval_into(&format!("(define concat {})", self::list::CONCAT), env);
+    eval_into(&format!("(define list {})", self::list::LIST), ctx);
+    eval_into(&format!("(define map {})", self::list::MAP), ctx);
+    eval_into(&format!("(define fold-left {})", self::list::FOLD_LEFT), ctx);
+    eval_into(&format!("(define filter {})", self::list::FILTER), ctx);
+    eval_into(&format!("(define concat {})", self::list::CONCAT), ctx);
 
 }
 
-pub fn load_arithmetic(env: &Env) {
-    let mut env = env.borrow_mut();
-    env.insert_here("=", free_fn("=", self::core::equals));
-    env.insert_here("+", free_fn("+", self::arithmetic::add_ints));
-    env.insert_here("+.", free_fn("+.", self::arithmetic::add_floats));
+pub fn load_arithmetic<T: 'static>(ctx: &mut Context<T>) {
+    ctx.set("=", free_fn("=", self::core::equals));
+    ctx.set("+", free_fn("+", self::arithmetic::add_ints));
+    ctx.set("+.", free_fn("+.", self::arithmetic::add_floats));
 
-    env.insert_here("-", free_fn("-", self::arithmetic::sub_ints));
-    env.insert_here("-.", free_fn("-.", self::arithmetic::sub_floats));
+    ctx.set("-", free_fn("-", self::arithmetic::sub_ints));
+    ctx.set("-.", free_fn("-.", self::arithmetic::sub_floats));
 
-    env.insert_here("*", free_fn("*", self::arithmetic::mul_ints));
-    env.insert_here("*.", free_fn("*.", self::arithmetic::mul_floats));
+    ctx.set("*", free_fn("*", self::arithmetic::mul_ints));
+    ctx.set("*.", free_fn("*.", self::arithmetic::mul_floats));
 
-    env.insert_here("/", free_fn("/", self::arithmetic::div_ints));
-    env.insert_here("/.", free_fn("/.", self::arithmetic::div_floats));
+    ctx.set("/", free_fn("/", self::arithmetic::div_ints));
+    ctx.set("/.", free_fn("/.", self::arithmetic::div_floats));
 }
 
-pub fn load_math(env: &Env) {
-    let mut env = env.borrow_mut();
-    env.insert_here("nan?", free_fn("nan?", self::math::is_nan));
-    env.insert_here("infinite?", free_fn("infinite?", self::math::is_infinite));
-    env.insert_here("finite?", free_fn("finite?", self::math::is_finite));
-    env.insert_here("normal?", free_fn("normal?", self::math::is_normal));
+pub fn load_math<T: 'static>(ctx: &mut Context<T>) {
+    ctx.set("nan?", free_fn("nan?", self::math::is_nan));
+    ctx.set("infinite?", free_fn("infinite?", self::math::is_infinite));
+    ctx.set("finite?", free_fn("finite?", self::math::is_finite));
+    ctx.set("normal?", free_fn("normal?", self::math::is_normal));
 
-    env.insert_here("floor", free_fn("floor", self::math::floor));
-    env.insert_here("ceil", free_fn("ceil", self::math::ceil));
-    env.insert_here("round", free_fn("round", self::math::round));
-    env.insert_here("trunc", free_fn("trunc", self::math::trunc));
+    ctx.set("floor", free_fn("floor", self::math::floor));
+    ctx.set("ceil", free_fn("ceil", self::math::ceil));
+    ctx.set("round", free_fn("round", self::math::round));
+    ctx.set("trunc", free_fn("trunc", self::math::trunc));
 
-    env.insert_here("fract", free_fn("fract", self::math::fract));
-    env.insert_here("sign_positive?", free_fn("sign_positive?", self::math::is_sign_positive));
-    env.insert_here("sign_negative?", free_fn("sign_negative?", self::math::is_sign_negative));
-    env.insert_here("recip", free_fn("recip", self::math::recip));
-    env.insert_here("sqrt", free_fn("sqrt", self::math::sqrt));
-    env.insert_here("exp", free_fn("exp", self::math::exp));
-    env.insert_here("exp2", free_fn("exp2", self::math::exp2));
-    env.insert_here("ln", free_fn("ln", self::math::ln));
-    env.insert_here("log2", free_fn("log2", self::math::log2));
-    env.insert_here("log10", free_fn("log10", self::math::log10));
-    env.insert_here("->degrees", free_fn("->degrees", self::math::to_degrees));
-    env.insert_here("->radians", free_fn("->radians", self::math::to_radians));
-    env.insert_here("cbrt", free_fn("cbrt", self::math::cbrt));
-    env.insert_here("sin", free_fn("sin", self::math::sin));
-    env.insert_here("cos", free_fn("cos", self::math::cos));
-    env.insert_here("tan", free_fn("tan", self::math::tan));
-    env.insert_here("asin", free_fn("asin", self::math::asin));
-    env.insert_here("acos", free_fn("acos", self::math::acos));
-    env.insert_here("atan", free_fn("atan", self::math::atan));
-    env.insert_here("exp_m1", free_fn("exp_m1", self::math::exp_m1));
-    env.insert_here("ln_1p", free_fn("ln_1p", self::math::ln_1p));
-    env.insert_here("sinh", free_fn("sinh", self::math::sinh));
-    env.insert_here("cosh", free_fn("cosh", self::math::cosh));
-    env.insert_here("tanh", free_fn("tanh", self::math::tanh));
-    env.insert_here("asinh", free_fn("asinh", self::math::asinh));
-    env.insert_here("acosh", free_fn("acosh", self::math::acosh));
-    env.insert_here("atanh", free_fn("atanh", self::math::atanh));
+    ctx.set("fract", free_fn("fract", self::math::fract));
+    ctx.set("sign_positive?", free_fn("sign_positive?", self::math::is_sign_positive));
+    ctx.set("sign_negative?", free_fn("sign_negative?", self::math::is_sign_negative));
+    ctx.set("recip", free_fn("recip", self::math::recip));
+    ctx.set("sqrt", free_fn("sqrt", self::math::sqrt));
+    ctx.set("exp", free_fn("exp", self::math::exp));
+    ctx.set("exp2", free_fn("exp2", self::math::exp2));
+    ctx.set("ln", free_fn("ln", self::math::ln));
+    ctx.set("log2", free_fn("log2", self::math::log2));
+    ctx.set("log10", free_fn("log10", self::math::log10));
+    ctx.set("->degrees", free_fn("->degrees", self::math::to_degrees));
+    ctx.set("->radians", free_fn("->radians", self::math::to_radians));
+    ctx.set("cbrt", free_fn("cbrt", self::math::cbrt));
+    ctx.set("sin", free_fn("sin", self::math::sin));
+    ctx.set("cos", free_fn("cos", self::math::cos));
+    ctx.set("tan", free_fn("tan", self::math::tan));
+    ctx.set("asin", free_fn("asin", self::math::asin));
+    ctx.set("acos", free_fn("acos", self::math::acos));
+    ctx.set("atan", free_fn("atan", self::math::atan));
+    ctx.set("exp_m1", free_fn("exp_m1", self::math::exp_m1));
+    ctx.set("ln_1p", free_fn("ln_1p", self::math::ln_1p));
+    ctx.set("sinh", free_fn("sinh", self::math::sinh));
+    ctx.set("cosh", free_fn("cosh", self::math::cosh));
+    ctx.set("tanh", free_fn("tanh", self::math::tanh));
+    ctx.set("asinh", free_fn("asinh", self::math::asinh));
+    ctx.set("acosh", free_fn("acosh", self::math::acosh));
+    ctx.set("atanh", free_fn("atanh", self::math::atanh));
 
-    env.insert_here("count_ones", free_fn("count_ones", self::math::count_ones));
-    env.insert_here("count_zeros", free_fn("count_zeros", self::math::count_zeros));
-    env.insert_here("leading_zeros", free_fn("leading_zeros", self::math::leading_zeros));
-    env.insert_here("trailing_zeros", free_fn("trailing_zeros", self::math::trailing_zeros));
-    env.insert_here("swap_bytes", free_fn("swap_bytes", self::math::swap_bytes));
-    env.insert_here("->big-endian", free_fn("->big-endian", self::math::to_be));
-    env.insert_here("->little-endian", free_fn("->little-endian", self::math::to_le));
-    env.insert_here("abs", free_fn("abs", self::math::abs));
-    env.insert_here("signum", free_fn("signum", self::math::signum));
-    env.insert_here("positive?", free_fn("positive?", self::math::is_positive));
-    env.insert_here("negative?", free_fn("negative?", self::math::is_negative));
+    ctx.set("count_ones", free_fn("count_ones", self::math::count_ones));
+    ctx.set("count_zeros", free_fn("count_zeros", self::math::count_zeros));
+    ctx.set("leading_zeros", free_fn("leading_zeros", self::math::leading_zeros));
+    ctx.set("trailing_zeros", free_fn("trailing_zeros", self::math::trailing_zeros));
+    ctx.set("swap_bytes", free_fn("swap_bytes", self::math::swap_bytes));
+    ctx.set("->big-endian", free_fn("->big-endian", self::math::to_be));
+    ctx.set("->little-endian", free_fn("->little-endian", self::math::to_le));
+    ctx.set("abs", free_fn("abs", self::math::abs));
+    ctx.set("signum", free_fn("signum", self::math::signum));
+    ctx.set("positive?", free_fn("positive?", self::math::is_positive));
+    ctx.set("negative?", free_fn("negative?", self::math::is_negative));
 }
 
-pub fn load_types(env: &Env) {
-    let mut env = env.borrow_mut();
-    env.insert_here("->int", free_fn("->int", self::types::to_int));
-    env.insert_here("->float", free_fn("->float", self::types::to_float));
-    env.insert_here("->string", free_fn("->string", self::types::to_string));
-    env.insert_here("->bool", free_fn("->bool", self::types::to_bool));
+pub fn load_types<T: 'static>(ctx: &mut Context<T>) {
+    ctx.set("->int", free_fn("->int", self::types::to_int));
+    ctx.set("->float", free_fn("->float", self::types::to_float));
+    ctx.set("->string", free_fn("->string", self::types::to_string));
+    ctx.set("->bool", free_fn("->bool", self::types::to_bool));
 
-    env.insert_here("int?", free_fn("int?", self::types::is_int));
-    env.insert_here("float?", free_fn("float?", self::types::is_float));
-    env.insert_here("bool?", free_fn("bool?", self::types::is_bool));
-    env.insert_here("string?", free_fn("string?", self::types::is_string));
-    env.insert_here("list?", free_fn("list?", self::types::is_list));
-    env.insert_here("lambda?", free_fn("lambda?", self::types::is_lambda));
-    env.insert_here("foreign-fn?", free_fn("foreign-fn?", self::types::is_foreign_fn));
-    env.insert_here("executable", free_fn("executable", self::types::is_executable));
+    ctx.set("int?", free_fn("int?", self::types::is_int));
+    ctx.set("float?", free_fn("float?", self::types::is_float));
+    ctx.set("bool?", free_fn("bool?", self::types::is_bool));
+    ctx.set("string?", free_fn("string?", self::types::is_string));
+    ctx.set("list?", free_fn("list?", self::types::is_list));
+    ctx.set("lambda?", free_fn("lambda?", self::types::is_lambda));
+    ctx.set("foreign-fn?", free_fn("foreign-fn?", self::types::is_foreign_fn));
+    ctx.set("executable", free_fn("executable", self::types::is_executable));
 }

--- a/src/stdlib/types.rs
+++ b/src/stdlib/types.rs
@@ -110,7 +110,7 @@ pub fn to_string<S>(values: &[Value<S>]) -> AresResult<Value<S>, S> {
     Ok(Value::String(Rc::new(s)))
 }
 
-fn to_string_helper<S>(value: &Value<S>) -> String {
+pub fn to_string_helper<S>(value: &Value<S>) -> String {
     match value {
         &Value::Int(i) => format!("{}", i),
         &Value::Float(f) => format!("{}", f),

--- a/src/stdlib/types.rs
+++ b/src/stdlib/types.rs
@@ -6,7 +6,7 @@ use super::util::expect_arity;
 
 macro_rules! gen_is_type {
     ($name: ident, $p: ident) => {
-        pub fn $name(values: &[Value]) -> AresResult<Value> {
+        pub fn $name<S>(values: &[Value<S>]) -> AresResult<Value<S>, S> {
             for item in values {
                 if let &Value::$p(_) = item {
                 } else {
@@ -27,7 +27,7 @@ gen_is_type!(is_ident, Ident);
 gen_is_type!(is_lambda, Lambda);
 gen_is_type!(is_foreign_fn, ForeignFn);
 
-pub fn is_executable(values: &[Value]) -> AresResult<Value> {
+pub fn is_executable<S>(values: &[Value<S>]) -> AresResult<Value<S>, S> {
     for item in values {
         match item {
             &Value::Lambda(_) => {},
@@ -40,7 +40,7 @@ pub fn is_executable(values: &[Value]) -> AresResult<Value> {
 }
 
 
-pub fn to_int(values: &[Value]) -> AresResult<Value> {
+pub fn to_int<S>(values: &[Value<S>]) -> AresResult<Value<S>, S> {
     try!(expect_arity(values, |l| l == 1, "exactly 1"));
 
     let res = match values.first().unwrap() {
@@ -57,7 +57,7 @@ pub fn to_int(values: &[Value]) -> AresResult<Value> {
     res
 }
 
-pub fn to_float(values: &[Value]) -> AresResult<Value> {
+pub fn to_float<S>(values: &[Value<S>]) -> AresResult<Value<S>, S> {
     try!(expect_arity(values, |l| l == 1, "exactly 1"));
 
     let res = match values.first().unwrap() {
@@ -72,7 +72,7 @@ pub fn to_float(values: &[Value]) -> AresResult<Value> {
     res
 }
 
-pub fn to_bool(values: &[Value]) -> AresResult<Value> {
+pub fn to_bool<S>(values: &[Value<S>]) -> AresResult<Value<S>, S> {
     try!(expect_arity(values, |l| l == 1, "exactly 1"));
 
     let res = match values.first().unwrap() {
@@ -103,14 +103,14 @@ pub fn to_bool(values: &[Value]) -> AresResult<Value> {
     res
 }
 
-pub fn to_string(values: &[Value]) -> AresResult<Value> {
+pub fn to_string<S>(values: &[Value<S>]) -> AresResult<Value<S>, S> {
     try!(expect_arity(values, |l| l == 1, "exactly 1"));
     let first = values.first().unwrap();
     let s = to_string_helper(&first);
     Ok(Value::String(Rc::new(s)))
 }
 
-fn to_string_helper(value: &Value) -> String {
+fn to_string_helper<S>(value: &Value<S>) -> String {
     match value {
         &Value::Int(i) => format!("{}", i),
         &Value::Float(f) => format!("{}", f),
@@ -121,7 +121,7 @@ fn to_string_helper(value: &Value) -> String {
         &Value::Ident(ref i) => format!("'{}", i),
 
         &ref l@Value::List(_) => {
-            fn build_buf(cur: &Value, buf: &mut String, seen: &mut HashSet<usize>) {
+            fn build_buf<S>(cur: &Value<S>, buf: &mut String, seen: &mut HashSet<usize>) {
                 match cur {
                     &Value::List(ref l) => {
                         let ptr = rc_to_usize(l);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -341,8 +341,8 @@ impl Error for ParseError_ {
     }
 }
 
-fn one_expr<'a, 'b>(tok: Token, tok_stream: &'a mut TokenIter<'b>)
-                     -> Result<Value, ParseError> {
+fn one_expr<'a, 'b, S>(tok: Token, tok_stream: &'a mut TokenIter<'b>)
+                     -> Result<Value<S>, ParseError> {
     use tokenizer::Token::*;
     match tok {
         Number(s) => Ok(try!(s.parse().map(Value::Int)
@@ -363,7 +363,7 @@ fn one_expr<'a, 'b>(tok: Token, tok_stream: &'a mut TokenIter<'b>)
     }
 }
 
-fn parse_one_expr<'a, 'b>(tok_stream: &'a mut TokenIter<'b>) -> Result<Option<Value>, ParseError> {
+fn parse_one_expr<'a, 'b, S>(tok_stream: &'a mut TokenIter<'b>) -> Result<Option<Value<S>>, ParseError> {
     if let Some(tok) = tok_stream.next() {
         one_expr(try!(tok), tok_stream).map(Some)
     } else {
@@ -371,8 +371,8 @@ fn parse_one_expr<'a, 'b>(tok_stream: &'a mut TokenIter<'b>) -> Result<Option<Va
     }
 }
 
-fn parse_list<'a, 'b>(tok_stream: &'a mut TokenIter<'b>)
-                      -> Result<Value, ParseError> {
+fn parse_list<'a, 'b, S>(tok_stream: &'a mut TokenIter<'b>)
+                      -> Result<Value<S>, ParseError> {
     let mut v = vec![];
     loop {
         if let Some(tok_or_err) = tok_stream.next() {
@@ -386,7 +386,7 @@ fn parse_list<'a, 'b>(tok_stream: &'a mut TokenIter<'b>)
     }
 }
 
-pub fn parse(input: &str) -> Result<Vec<Value>, ParseError> {
+pub fn parse<S>(input: &str) -> Result<Vec<Value<S>>, ParseError> {
     let mut v = vec![];
     let mut tok_iter = TokenIter::new(input);
      while let Some(value) = try!(parse_one_expr(&mut tok_iter)) {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -151,7 +151,7 @@ impl<'a> TokenIter<'a>
         }
     }
 
-    fn read_x_escape<'b>(&'b mut self, start: usize, escape_start: Position, string_start: Position) 
+    fn read_x_escape<'b>(&'b mut self, start: usize, escape_start: Position, string_start: Position)
                          -> Result<char, ParseError> {
         // hand-rolled version of self.iter.take(2).collect()
         let v : Vec<_> = self.iter.next().map_or(vec![], (|x| self.iter.next().map_or(vec![x], |y| vec![x,y])));
@@ -294,13 +294,13 @@ fn parse_error<T>(p: ParseError_) -> Result<T, ParseError> {
     Err(ParseError(p))
 }
 
-impl<'a> fmt::Display for ParseError {
+impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl<'a> Error for ParseError {
+impl Error for ParseError {
     fn description(&self) -> &str { self.0.description() }
 }
 

--- a/tests/tokenization.rs
+++ b/tests/tokenization.rs
@@ -1,10 +1,10 @@
 extern crate ares;
-use ares::tokenizer::parse;
-use ares::Value;
+use ares::tokenizer::{parse, ParseError};
+use ares::{Value, AresResult};
 
 macro_rules! parse_fail {
     ($prog: expr, $estr: expr) => ({
-        let parsed = parse($prog);
+        let parsed: Result<Vec<Value<()>>, ParseError> = parse($prog);
         assert!(parsed.is_err());
         let err = parsed.unwrap_err();
         assert_eq!(format!("{}", err), $estr)
@@ -13,11 +13,11 @@ macro_rules! parse_fail {
 
 macro_rules! parse_ok {
     ($prog: expr) => ({
-        let parsed = parse($prog);
+        let parsed: Result<Vec<Value<()>>, ParseError> = parse($prog);
         assert!(parsed.is_ok())
     });
     ($prog: expr, $v: expr) => ({
-        let parsed = parse($prog);
+        let parsed: Result<Vec<Value<()>>, ParseError> = parse($prog);
         assert!(parsed.is_ok());
         let v = parsed.unwrap();
         assert_eq!(v[0], Value::from($v));

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -26,19 +26,13 @@ macro_rules! eval_err {
     }
 }
 
-fn basic_environment() -> Rc<RefCell<Environment>> {
-    let env = Environment::new();
-    let env = Rc::new(RefCell::new(env));
-    stdlib::load_all(&env);
-    env
-}
+pub fn e(program: &str) -> AresResult<Value<()>, ()> {
+    let res = {
+        let mut ctx = Context::<()>::new();
+        let mut dummy = ();
+        let mut ctx = ctx.load(&mut dummy);
 
-pub fn e(program: &str) -> AresResult<Value> {
-    let trees = parse(program).unwrap();
-    let mut env = basic_environment();
-    let mut last = None;
-    for tree in trees {
-        last = Some(try!(eval(&tree, &mut env)))
-    }
-    Ok(last.expect("no program found"))
+        ctx.eval_str(program)
+    };
+    res
 }


### PR DESCRIPTION
The "Context" is the main API level that the user will interact with.  Instead of passing `Env` around all the time, we'll instead pass around Contexts.  There are two types of Contexts: Regular `Context` and a `LoadedContext`.  

1. The `Context` will allow the library user to read and write into the global environment but not evaluate anything.
2. The `LoadedContext` is "loaded" with a mutable reference to some rust state that the library user wants to have mutated by the evaluation of lisp code.

The ultimate goal is to have something like this be possible:

```rust
let mut ctx = Context::new();
let mut counter = 0;
ctx.env().add_function("increment-counter", |ctx, _args| {
    *ctx.state = ctx.state + 1; // increment the counter.
});

{
    let loaded = ctx.load(&mut counter);
    for _ in 0 .. 5 {
        loaded.call_global("increment-counter", vec![]);
    }
}

assert_eq!(counter, 5);

```

@bwo : I'm nowhere near done, but I'd like you to be updated and get feedback as soon as possible.