### PR TITLE
separate out an apply()

### DIFF
--- a/src/eval/environment.rs
+++ b/src/eval/environment.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::collections::HashMap;
 use std::cell::RefCell;
 
-use ::{Value, AresResult};
+use ::{Value, AresResult, Function};
 
 use super::{ForeignFunction};
 
@@ -83,7 +83,7 @@ impl Environment {
         let boxed: Rc<Fn(&mut Iterator<Item=Value>) -> AresResult<Value>> = Rc::new(f);
         self.bindings.insert(
             name.to_string(),
-            Value::ForeignFn(ForeignFunction::new_free_function(name.to_string(), boxed)));
+            Value::LispFunction(Function::ForeignFn(ForeignFunction::new_free_function(name.to_string(), boxed))));
     }
 
     pub fn set_uneval_function<F>(&mut self, name: &str, f: F)
@@ -92,7 +92,7 @@ impl Environment {
         let boxed: Rc<Fn(&mut Iterator<Item=&Value>, &Env, &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value>> = Rc::new(f);
         self.bindings.insert(
             name.to_string(),
-            Value::ForeignFn(ForeignFunction::new_uneval_function(name.to_string(), boxed)));
+            Value::LispFunction(Function::ForeignFn(ForeignFunction::new_uneval_function(name.to_string(), boxed))));
     }
 }
 

--- a/src/stdlib/core.rs
+++ b/src/stdlib/core.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use ::{Value, Environment, Procedure, AresResult, AresError, ParamBinding};
+use ::{Value, Environment, Procedure, AresResult, AresError, ParamBinding, Function};
 use super::util::{unwrap_or_arity_err, no_more_or_arity_err};
 
 pub fn equals(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
@@ -55,12 +55,13 @@ pub fn lambda(args: &mut Iterator<Item=&Value>,
         return Err(AresError::NoLambdaBody);
     }
 
-    Ok(Value::Lambda(
+    Ok(Value::LispFunction(
+        Function::Lambda(
             Procedure::new(
                 None,
                 Rc::new(bodies),
                 param_names,
-                env.clone())))
+                env.clone()))))
 }
 
 pub fn define(args: &mut Iterator<Item=&Value>,

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -80,6 +80,7 @@ pub fn load_list(env: &Env) {
     eval_into(&format!("(define map {})", self::list::MAP), env);
     eval_into(&format!("(define fold-left {})", self::list::FOLD_LEFT), env);
     eval_into(&format!("(define filter {})", self::list::FILTER), env);
+    eval_into(&format!("(define concat {})", self::list::CONCAT), env);
 
 }
 

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -29,3 +29,8 @@ fn test_fold_left() {
     eval_ok!("(fold-left (list 1 2 3) 0 (lambda (a b) (+ a b)))", 6);
     eval_ok!("(fold-left '(1 2 3) 1 *)", 6);
 }
+
+#[test]
+fn test_concat() {
+    eval_ok!("(concat '(1 2) '(3 4))", vec![1, 2, 3, 4]);
+}


### PR DESCRIPTION
also separates out functions into a single variant in Value

so something like this. Not sure this reduces the number of clones overall, actually, but I wanted to put up an example of what I was thinking of.

I opted to just pull in `apply` directly in list.rs, partly to avoid having to change the signature of every `UnEvalFn` to accept an additional parameter and partly because I wasn't certain what the rationale for passing `eval` in as an argument was.