### PR TITLE
Redo rust-based "foreign" functions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,9 +13,7 @@ pub enum AresError {
     UnexecutableValue(Value),
     ExecuteEmptyList,
 
-    NoLambdaArgsList,
     UnexpectedArgsList(Value),
-    NoLambdaBody,
 
     IllegalConversion{value: Value, into: String},
     UndefinedName(String),

--- a/src/eval/environment.rs
+++ b/src/eval/environment.rs
@@ -73,26 +73,8 @@ impl Environment {
         }
     }
 
-    pub fn insert_current_level(&mut self, name: String, value: Value) -> Option<Value> {
-        self.bindings.insert(name, value)
-    }
-
-    pub fn set_function<F>(&mut self, name: &str, f: F)
-    where F: Fn(&mut Iterator<Item=Value>) -> AresResult<Value> + 'static
-    {
-        let boxed: Rc<Fn(&mut Iterator<Item=Value>) -> AresResult<Value>> = Rc::new(f);
-        self.bindings.insert(
-            name.to_string(),
-            Value::ForeignFn(ForeignFunction::new_free_function(name.to_string(), boxed)));
-    }
-
-    pub fn set_uneval_function<F>(&mut self, name: &str, f: F)
-    where F: Fn(&mut Iterator<Item=&Value>, &Env, &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> + 'static
-    {
-        let boxed: Rc<Fn(&mut Iterator<Item=&Value>, &Env, &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value>> = Rc::new(f);
-        self.bindings.insert(
-            name.to_string(),
-            Value::ForeignFn(ForeignFunction::new_uneval_function(name.to_string(), boxed)));
+    pub fn insert_here<S: Into<String>>(&mut self, name: S, value: Value) -> Option<Value> {
+        self.bindings.insert(name.into(), value)
     }
 }
 

--- a/src/eval/environment.rs
+++ b/src/eval/environment.rs
@@ -2,9 +2,7 @@ use std::rc::Rc;
 use std::collections::HashMap;
 use std::cell::RefCell;
 
-use ::{Value, AresResult};
-
-use super::{ForeignFunction};
+use ::Value;
 
 pub type Env = Rc<RefCell<Environment>>;
 pub struct Environment {

--- a/src/eval/foreign_function.rs
+++ b/src/eval/foreign_function.rs
@@ -7,17 +7,19 @@ pub use super::environment::{Env, Environment};
 #[derive(Clone)]
 pub struct ForeignFunction {
     pub name: String,
-    pub function: Rc<Fn(&[Value], &Env, Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value>>
+    pub function: Rc<Fn(&[Value], &Env, &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value>>
 }
 
 pub fn free_fn<S, F>(name: S, func: F) -> Value
 where S: Into<String>,
       F: Fn(&[Value]) -> AresResult<Value> + 'static
 {
-    let closure = |values: &[Value], env: &Env, eval: Fn(&Value, &Env) -> AresResult<Value>| {
-        let evaluated: Vec<_> = values.iter().map(|v| eval(v, env)).collect();
-        func(&evaluated)
+    let closure = move |values: &[Value], env: &Env, eval: &Fn(&Value, &Env) -> AresResult<Value>| {
+        let evaluated: Result<Vec<_>, _> = values.iter().map(|v| eval(v, env)).collect();
+        let evaluated = try!(evaluated);
+        func(&evaluated[..])
     };
+
     let boxed = Rc::new(closure);
     Value::ForeignFn(ForeignFunction {
         name: name.into(),
@@ -28,7 +30,7 @@ where S: Into<String>,
 
 pub fn ast_fn<S, F>(name: S, func: F) -> Value
 where S: Into<String>,
-      F: Fn(&[Value], &Env, Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> + 'static
+      F: Fn(&[Value], &Env, &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> + 'static
 {
     let boxed = Rc::new(func);
     Value::ForeignFn(ForeignFunction {

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -28,16 +28,16 @@ pub fn eval(value: &Value, env: &Rc<RefCell<Environment>>) -> AresResult<Value> 
             }
         }
 
-        &Value::List(ref l) => {
-            let mut items = l.iter();
-            let head = match items.next() {
+        &Value::List(ref items) => {
+            let head = match items.first() {
                 Some(h) => h,
                 None => return Err(AresError::ExecuteEmptyList)
             };
+            let items = &items[1..];
 
             match try!(eval(head, env)) {
                 Value::Lambda(procedure) => {
-                    let evald: AresResult<Vec<Value>> = items.map(|v| eval(v, env)).collect();
+                    let evald: AresResult<Vec<Value>> = items.iter().map(|v| eval(v, env)).collect();
                     let evald = try!(evald);
                     let new_env = procedure.gen_env(evald.into_iter());
                     let mut last = None;
@@ -46,16 +46,9 @@ pub fn eval(value: &Value, env: &Rc<RefCell<Environment>>) -> AresResult<Value> 
                     }
                     last.ok_or(AresError::NoLambdaBody)
                 }
-                /*Value::ForeignFn(ff) => {
-                    match ff.function {
-                        FfType::FreeFn(ff) => {
-                            let evald: AresResult<Vec<Value>> = items.map(|v| eval(v, env)).collect();
-                            let evald = try!(evald);
-                            (ff)(&mut evald.into_iter())
-                        }
-                        FfType::UnEvalFn(uef) => (uef)(&mut items, env, &|v, e| eval(v, e))
-                    }
-                }*/
+                Value::ForeignFn(ff) => {
+                    (ff.function)(items, env, &|v, e| eval(v, e))
+                }
                 x => Err(AresError::UnexecutableValue(x))
             }
         }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use super::{Value, AresError, AresResult};
 
 pub use self::environment::{Env, Environment};
-pub use self::foreign_function::{ForeignFunction, FfType};
+pub use self::foreign_function::{ForeignFunction, free_fn, ast_fn};
 pub use self::procedure::{Procedure, ParamBinding};
 
 mod environment;
@@ -46,7 +46,7 @@ pub fn eval(value: &Value, env: &Rc<RefCell<Environment>>) -> AresResult<Value> 
                     }
                     last.ok_or(AresError::NoLambdaBody)
                 }
-                Value::ForeignFn(ff) => {
+                /*Value::ForeignFn(ff) => {
                     match ff.function {
                         FfType::FreeFn(ff) => {
                             let evald: AresResult<Vec<Value>> = items.map(|v| eval(v, env)).collect();
@@ -55,7 +55,7 @@ pub fn eval(value: &Value, env: &Rc<RefCell<Environment>>) -> AresResult<Value> 
                         }
                         FfType::UnEvalFn(uef) => (uef)(&mut items, env, &|v, e| eval(v, e))
                     }
-                }
+                }*/
                 x => Err(AresError::UnexecutableValue(x))
             }
         }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -60,7 +60,8 @@ pub fn apply<'a>(func: &Value, args: &[Value], env: &'a Env) -> AresResult<Value
             for body in &*procedure.bodies {
                 last = Some(try!(eval(body, &new_env)));
             }
-            last.ok_or(AresError::NoLambdaBody)
+            // it's impossible to make a lambda without a body
+            Ok(last.unwrap())
         }
         Value::ForeignFn(ff) => {
             (ff.function)(args, env, &|a, b| eval(a, b))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,16 @@ mod error;
 pub mod util;
 
 pub use tokenizer::parse;
-pub use eval::{Procedure, eval, ForeignFunction, Env, Environment, ParamBinding};
+pub use eval::{
+    Procedure,
+    eval,
+    ForeignFunction,
+    Env,
+    Environment,
+    ParamBinding,
+    free_fn,
+    ast_fn,
+};
 pub use error::{AresError, AresResult};
 
 macro_rules! gen_from {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,15 +87,6 @@ impl <'a> From<&'a str> for Value {
     }
 }
 
-impl <S, F> From<(S, F)> for Value
-where S: Into<String>,
-      F: Fn(&mut Iterator<Item=Value>) -> AresResult<Value> + 'static
-{
-    fn from((name, f): (S, F)) -> Value {
-        Value::ForeignFn(ForeignFunction::new_free_function(name.into(), Rc::new(f)))
-    }
-}
-
 impl PartialEq for Value {
     fn eq(&self, other: &Value) -> bool {
         use ::Value::*;

--- a/src/stdlib/arithmetic.rs
+++ b/src/stdlib/arithmetic.rs
@@ -6,11 +6,11 @@ macro_rules! gen_fold {
         {
         let mut cur = $default;
         for a in $args {
-            if let $var(name) = a {
+            if let &$var(name) = a {
                 ($op)(&mut cur, name);
             } else {
                 return Err(AresError::UnexpectedType {
-                    value: a,
+                    value: a.clone(),
                     expected: stringify!($var).to_string()
                 });
             }
@@ -103,14 +103,16 @@ pub fn div_floats(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, 1.0f64, Value::Float, |acc: &mut f64, v: f64| *acc /= v)
 }
 
+
+// TODO: move this to a new strings module
 pub fn concat(args: &[Value]) -> AresResult<Value> {
     let mut buffer = String::new();
     for v in args {
-        if let Value::String(s) = v {
-            buffer.push_str(&s)
+        if let &Value::String(ref s) = v {
+            buffer.push_str(&s[..])
         } else {
             return Err(AresError::UnexpectedType {
-                value: v,
+                value: v.clone(),
                 expected: "Value::String".into()
             })
         }

--- a/src/stdlib/arithmetic.rs
+++ b/src/stdlib/arithmetic.rs
@@ -23,15 +23,15 @@ macro_rules! gen_fold {
     }
 }
 
-pub fn add_ints(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn add_ints(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, 0i64, Value::Int, |acc: &mut i64, v: i64| *acc += v)
 }
 
-pub fn add_floats(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn add_floats(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, 0.0f64, Value::Float, |acc: &mut f64, v: f64| *acc += v)
 }
 
-pub fn sub_ints(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn sub_ints(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, None, Value::Int, |acc: &mut Option<(bool, i64)>, v: i64| {
         if let &mut Some((ref mut first, ref mut acc)) = acc {
             if *first {
@@ -52,7 +52,7 @@ pub fn sub_ints(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
     })
 }
 
-pub fn sub_floats(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn sub_floats(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, None, Value::Float, |acc: &mut Option<(bool, f64)>, v: f64| {
         if let &mut Some((ref mut first, ref mut acc)) = acc {
             if *first {
@@ -73,15 +73,15 @@ pub fn sub_floats(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
     })
 }
 
-pub fn mul_ints(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn mul_ints(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, 1i64, Value::Int, |acc: &mut i64, v: i64| *acc *= v)
 }
 
-pub fn mul_floats(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn mul_floats(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, 1.0f64, Value::Float, |acc: &mut f64, v: f64| *acc *= v)
 }
 
-pub fn div_ints(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn div_ints(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, None, Value::Int, |acc: &mut Option<i64>, v: i64| {
         if let &mut Some(ref mut acc) = acc {
             *acc /= v
@@ -99,11 +99,11 @@ pub fn div_ints(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
     })
 }
 
-pub fn div_floats(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn div_floats(args: &[Value]) -> AresResult<Value> {
     gen_fold!(args, 1.0f64, Value::Float, |acc: &mut f64, v: f64| *acc /= v)
 }
 
-pub fn concat(args: &mut Iterator<Item=Value>) -> AresResult<Value> {
+pub fn concat(args: &[Value]) -> AresResult<Value> {
     let mut buffer = String::new();
     for v in args {
         if let Value::String(s) = v {

--- a/src/stdlib/core.rs
+++ b/src/stdlib/core.rs
@@ -2,25 +2,16 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use ::{Value, Environment, Procedure, AresResult, AresError, ParamBinding};
-use super::util::{unwrap_or_arity_err, no_more_or_arity_err};
+use super::util::expect_arity;
 
 pub fn equals(args: &[Value]) -> AresResult<Value> {
-    let mut args = args.iter();
-    let first = try!(unwrap_or_arity_err(args.next(), 0, "at least 2"));
-    let mut seen_2 = false;
+    try!(expect_arity(args, |l| l >= 2, "at least 2"));
+    let first = &args[0];
 
-    for next in args {
-        seen_2 = true;
-        if next != first {
+    for next in args.iter().skip(1) {
+        if *next != *first {
             return Ok(Value::Bool(false))
         }
-    }
-
-    if !seen_2 {
-        return Err(AresError::UnexpectedArity {
-            found: 1,
-            expected: "at least 2".into()
-        });
     }
 
     Ok(Value::Bool(true))
@@ -29,8 +20,8 @@ pub fn equals(args: &[Value]) -> AresResult<Value> {
 pub fn lambda(args: &[Value],
               env: &Rc<RefCell<Environment>>,
               _eval: &Fn(&Value, &Rc<RefCell<Environment>>) -> AresResult<Value>) -> AresResult<Value> {
-    let mut args = args.iter();
-    let param_names = match try!(unwrap_or_arity_err(args.next(), 0, "2 or more")) {
+    try!(expect_arity(args, |l| l >= 2, "at least 2"));
+    let param_names = match &args[0] {
         &Value::List(ref v) => {
             let r: AresResult<Vec<String>> = v.iter().map(|n| {
                 match n {
@@ -51,11 +42,7 @@ pub fn lambda(args: &[Value],
         }
     };
 
-    let bodies:Vec<_> = args.cloned().collect();
-
-    if bodies.len() == 0 {
-        return Err(AresError::NoLambdaBody);
-    }
+    let bodies:Vec<_> = args.iter().skip(1).cloned().collect();
 
     Ok(Value::Lambda(
             Procedure::new(
@@ -68,8 +55,8 @@ pub fn lambda(args: &[Value],
 pub fn define(args: &[Value],
               env: &Rc<RefCell<Environment>>,
               eval: &Fn(&Value, &Rc<RefCell<Environment>>) -> AresResult<Value>) -> AresResult<Value> {
-    let mut args = args.iter();
-    let name: String = match try!(unwrap_or_arity_err(args.next(), 0, "exactly 2")) {
+    try!(expect_arity(args, |l| l == 2, "exactly 2"));
+    let name: String = match &args[0] {
         &Value::Ident(ref s) => (**s).clone(),
         &ref other => return Err(AresError::UnexpectedType {
             value: other.clone(),
@@ -81,11 +68,9 @@ pub fn define(args: &[Value],
         return Err(AresError::AlreadyDefined(name.into()))
     }
 
-    let value = try!(unwrap_or_arity_err(args.next(), 1, "exactly 2"));
-
-    try!(no_more_or_arity_err(&mut args, 2, "exactly 2"));
-
+    let value = &args[1];
     let result = try!(eval(value, env));
+
     env.borrow_mut().insert_here(name, result.clone());
     Ok(result)
 }
@@ -93,8 +78,8 @@ pub fn define(args: &[Value],
 pub fn set(args: &[Value],
               env: &Rc<RefCell<Environment>>,
               eval: &Fn(&Value, &Rc<RefCell<Environment>>) -> AresResult<Value>) -> AresResult<Value> {
-    let mut args = args.iter();
-    let name = match try!(unwrap_or_arity_err(args.next(), 0, "exactly 2")) {
+    try!(expect_arity(args, |l| l == 2, "exactly 2"));
+    let name = match &args[0] {
         &Value::Ident(ref s) => (**s).clone(),
         &ref v => return Err(AresError::UnexpectedType {
             value: v.clone(),
@@ -102,14 +87,11 @@ pub fn set(args: &[Value],
         }),
     };
 
-    let value = try!(unwrap_or_arity_err(args.next(), 1, "exactly 2"));
-
-    try!(no_more_or_arity_err(&mut args, 2, "exactly 2"));
+    let value = &args[1];
 
     if !env.borrow().is_defined(&name) {
         return Err(AresError::UndefinedName(name.into()))
     }
-
 
     let result = try!(eval(value, env));
     env.borrow_mut().with_value_mut(&name, |v| *v = result.clone());
@@ -119,21 +101,15 @@ pub fn set(args: &[Value],
 pub fn quote(args: &[Value],
               _env: &Rc<RefCell<Environment>>,
               _eval: &Fn(&Value, &Rc<RefCell<Environment>>) -> AresResult<Value>) -> AresResult<Value> {
-    let mut args = args.iter();
-    let first = try!(unwrap_or_arity_err(args.next().cloned(), 0, "exactly 1"));
-    try!(no_more_or_arity_err(&mut args, 1, "exactly 1"));
-    Ok(first)
+    try!(expect_arity(args, |l| l == 1, "exactly 1"));
+    Ok(args[0].clone())
 }
 
 pub fn cond(args: &[Value],
             env: &Rc<RefCell<Environment>>,
             eval: &Fn(&Value, &Rc<RefCell<Environment>>) -> AresResult<Value>) -> AresResult<Value> {
-    let mut args = args.iter();
-    let (cond, true_branch, false_branch) =
-        (try!(unwrap_or_arity_err(args.next(), 0, "exactly 3")),
-         try!(unwrap_or_arity_err(args.next(), 1, "exactly 3")),
-         try!(unwrap_or_arity_err(args.next(), 2, "exactly 3")));
-
+    try!(expect_arity(args, |l| l == 3, "exactly 3"));
+    let (cond, true_branch, false_branch) = (&args[0], &args[1], &args[2]);
     match try!(eval(cond, env)) {
         Value::Bool(true) => eval(true_branch, env),
         Value::Bool(false) => eval(false_branch, env),

--- a/src/stdlib/list.rs
+++ b/src/stdlib/list.rs
@@ -1,15 +1,17 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use ::{Value, Env, AresResult, AresError, ForeignFunction};
+use ::{Value, Env, AresResult, AresError, free_fn};
 use super::util::{no_more_or_arity_err, unwrap_or_arity_err};
 
-pub fn build_list(args: &mut Iterator<Item=&Value>,
+pub fn build_list(args: &[Value],
                   env: &Env,
                   eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
+    let mut args = args.iter();
     let vec = Rc::new(RefCell::new(Some(Vec::<Value>::new())));
     let writer = vec.clone();
-    let func = move |values: &mut Iterator<Item=Value>| {
+
+    let func = move |values: &[Value]| -> AresResult<Value> {
         match &mut *writer.borrow_mut() {
             &mut Some(ref mut adder) => {
                 let mut last = None;
@@ -19,7 +21,7 @@ pub fn build_list(args: &mut Iterator<Item=&Value>,
                 }
 
                 match last {
-                    Some(v) => Ok(v),
+                    Some(v) => Ok(v.clone()),
                     None => Err(AresError::UnexpectedArity {
                         found: 0,
                         expected: "at least 1".to_string()
@@ -33,8 +35,7 @@ pub fn build_list(args: &mut Iterator<Item=&Value>,
         }
     };
 
-    let boxed_fn = ForeignFunction::new_free_function("add".into(), Rc::new(func));
-    let boxed_fn = Value::ForeignFn(boxed_fn);
+    let boxed_fn: Value = free_fn("add", func);
 
     let evaluator = match args.next() {
         Some(lambda) => lambda.clone(),
@@ -60,9 +61,10 @@ pub fn build_list(args: &mut Iterator<Item=&Value>,
     Ok(Value::new_list(v.take().unwrap()))
 }
 
-pub fn foreach(args: &mut Iterator<Item=&Value>,
+pub fn foreach(args: &[Value],
                env: &Env,
                eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
+    let mut args = args.iter();
     let should_be_list = try!(unwrap_or_arity_err(args.next(), 0, "exactly 2"));
     let list = match try!(eval(should_be_list, env)) {
         Value::List(ref l) => l.clone(),
@@ -73,7 +75,7 @@ pub fn foreach(args: &mut Iterator<Item=&Value>,
     };
 
     let func = try!(unwrap_or_arity_err(args.next().cloned(), 1, "exactly 2"));
-    try!(no_more_or_arity_err(args, 2, "exactly 2"));
+    try!(no_more_or_arity_err(&mut args, 2, "exactly 2"));
 
     let mut count = 0;
     for element in list.iter() {

--- a/src/stdlib/logical.rs
+++ b/src/stdlib/logical.rs
@@ -1,6 +1,6 @@
 use ::{Value, AresResult, Env, AresError};
 
-pub fn and(args: &mut Iterator<Item=&Value>,
+pub fn and(args: &[Value],
            env: &Env,
            eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
     for value in args {
@@ -16,7 +16,7 @@ pub fn and(args: &mut Iterator<Item=&Value>,
     Ok(Value::Bool(true))
 }
 
-pub fn or(args: &mut Iterator<Item=&Value>,
+pub fn or(args: &[Value],
            env: &Env,
            eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
     for value in args {
@@ -32,7 +32,7 @@ pub fn or(args: &mut Iterator<Item=&Value>,
     Ok(Value::Bool(false))
 }
 
-pub fn xor(args: &mut Iterator<Item=&Value>,
+pub fn xor(args: &[Value],
            env: &Env,
            eval: &Fn(&Value, &Env) -> AresResult<Value>) -> AresResult<Value> {
     let mut found_true = false;

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -1,5 +1,5 @@
 use ::{Value, AresResult, AresError};
-use super::util::{unwrap_or_arity_err, no_more_or_arity_err};
+use super::util::expect_arity;
 
 macro_rules! gen_num_method {
     ($name: ident, $v: path) => {
@@ -9,16 +9,15 @@ macro_rules! gen_num_method {
         gen_num_method!($name, $inv, $outv, |a| a);
     };
     ($name: ident, $inv: path, $outv: path, $conv: expr) => {
-        pub fn $name(it: &[Value]) -> AresResult<Value> {
-            let mut it = it.iter();
-            let value = match try!(unwrap_or_arity_err(it.nth(0), 0, "exactly 1")) {
+        pub fn $name(values: &[Value]) -> AresResult<Value> {
+            try!(expect_arity(values, |l| l == 1, "exactly 1"));
+            let value = match values.first().unwrap() {
                 &$inv(v) => $outv($conv(v.$name())),
                 other => return Err(AresError::UnexpectedType{
                     value: other.clone(),
                     expected: stringify!($inv).into()
                 })
             };
-            try!(no_more_or_arity_err(&mut it, 1, "exactly 1"));
             Ok(value)
         }
     }

--- a/src/stdlib/math.rs
+++ b/src/stdlib/math.rs
@@ -9,15 +9,16 @@ macro_rules! gen_num_method {
         gen_num_method!($name, $inv, $outv, |a| a);
     };
     ($name: ident, $inv: path, $outv: path, $conv: expr) => {
-        pub fn $name(it: &mut Iterator<Item=Value>) -> AresResult<Value> {
-            let value = match try!(unwrap_or_arity_err(it.next(), 0, "exactly 1")) {
-                $inv(v) => $outv($conv(v.$name())),
+        pub fn $name(it: &[Value]) -> AresResult<Value> {
+            let mut it = it.iter();
+            let value = match try!(unwrap_or_arity_err(it.nth(0), 0, "exactly 1")) {
+                &$inv(v) => $outv($conv(v.$name())),
                 other => return Err(AresError::UnexpectedType{
-                    value: other,
+                    value: other.clone(),
                     expected: stringify!($inv).into()
                 })
             };
-            try!(no_more_or_arity_err(it, 1, "exactly 1"));
+            try!(no_more_or_arity_err(&mut it, 1, "exactly 1"));
             Ok(value)
         }
     }

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -8,33 +8,19 @@ pub mod list;
 pub mod logical;
 
 pub mod util {
-    use ::AresError;
-
-    pub fn unwrap_or_arity_err<T, S>(value: Option<T>, seen_already: u16, expected: S) -> Result<T, AresError>
-    where S: Into<String> {
-        match value {
-            Some(v) => Ok(v),
-            None => Err(AresError::UnexpectedArity {
-                found: seen_already,
-                expected: expected.into()
-            })
-        }
-    }
-
-    pub fn no_more_or_arity_err<S, T, I: ?Sized>(iter: &mut I, seen_already: u16, expected: S) -> Result<(), AresError>
-    where I: Iterator<Item=T>, S: Into<String>
-    {
-        let count = iter.count();
-        if count > 0 {
-            Err(AresError::UnexpectedArity {
-                found: seen_already + count as u16,
-                expected: expected.into()
-            })
-        } else {
+    use ::{AresError, AresResult};
+    pub fn expect_arity<F, S: Into<String>, T>(slice: &[T], expected: F, expect_str: S) -> AresResult<()>
+    where S: Into<String>, F: FnOnce(usize) -> bool {
+        let len = slice.len();
+        if expected(len) {
             Ok(())
+        } else {
+            Err(AresError::UnexpectedArity{
+                found: len as u16,
+                expected: expect_str.into()
+            })
         }
     }
-
 }
 
 fn eval_into<S: AsRef<str>>(src: &S, env: &Env) {

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -56,9 +56,9 @@ pub fn load_all(env: &Env) {
 
 pub fn load_logical(env: &Env) {
     let mut env = env.borrow_mut();
-    env.insert_here("and", free_fn("and", self::logical::and));
-    env.insert_here("or", free_fn("or", self::logical::or));
-    env.insert_here("xor", free_fn("xor", self::logical::xor));
+    env.insert_here("and", ast_fn("and", self::logical::and));
+    env.insert_here("or", ast_fn("or", self::logical::or));
+    env.insert_here("xor", ast_fn("xor", self::logical::xor));
 }
 
 pub fn load_core(env: &Env) {

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -1,4 +1,4 @@
-use ::Env;
+use ::{Env, free_fn, ast_fn};
 
 pub mod arithmetic;
 pub mod math;
@@ -56,25 +56,25 @@ pub fn load_all(env: &Env) {
 
 pub fn load_logical(env: &Env) {
     let mut env = env.borrow_mut();
-    env.set_uneval_function("and", self::logical::and);
-    env.set_uneval_function("or", self::logical::or);
-    env.set_uneval_function("xor", self::logical::xor);
+    env.insert_here("and", free_fn("and", self::logical::and));
+    env.insert_here("or", free_fn("or", self::logical::or));
+    env.insert_here("xor", free_fn("xor", self::logical::xor));
 }
 
 pub fn load_core(env: &Env) {
     let mut env = env.borrow_mut();
-    env.set_uneval_function("quote", self::core::quote);
-    env.set_uneval_function("if", self::core::cond);
-    env.set_uneval_function("set", self::core::set);
-    env.set_uneval_function("define", self::core::define);
-    env.set_uneval_function("lambda", self::core::lambda);
+    env.insert_here("quote", ast_fn("quote", self::core::quote));
+    env.insert_here("if", ast_fn("if", self::core::cond));
+    env.insert_here("set", ast_fn("set", self::core::set));
+    env.insert_here("define", ast_fn("define", self::core::define));
+    env.insert_here("lambda", ast_fn("lambda", self::core::lambda));
 }
 
 pub fn load_list(env: &Env) {
     {
         let mut env = env.borrow_mut();
-        env.set_uneval_function("build-list", self::list::build_list);
-        env.set_uneval_function("for-each", self::list::foreach);
+        env.insert_here("build-list", ast_fn("build-list", self::list::build_list));
+        env.insert_here("for-each", ast_fn("for-each", self::list::foreach));
     }
     eval_into(&format!("(define list {})", self::list::LIST), env);
     eval_into(&format!("(define map {})", self::list::MAP), env);
@@ -85,86 +85,86 @@ pub fn load_list(env: &Env) {
 
 pub fn load_arithmetic(env: &Env) {
     let mut env = env.borrow_mut();
-    env.set_function("=", self::core::equals);
-    env.set_function("+", self::arithmetic::add_ints);
-    env.set_function("+.", self::arithmetic::add_floats);
+    env.insert_here("=", free_fn("=", self::core::equals));
+    env.insert_here("+", free_fn("+", self::arithmetic::add_ints));
+    env.insert_here("+.", free_fn("+.", self::arithmetic::add_floats));
 
-    env.set_function("-", self::arithmetic::sub_ints);
-    env.set_function("-.", self::arithmetic::sub_floats);
+    env.insert_here("-", free_fn("-", self::arithmetic::sub_ints));
+    env.insert_here("-.", free_fn("-.", self::arithmetic::sub_floats));
 
-    env.set_function("*", self::arithmetic::mul_ints);
-    env.set_function("*.", self::arithmetic::mul_floats);
+    env.insert_here("*", free_fn("*", self::arithmetic::mul_ints));
+    env.insert_here("*.", free_fn("*.", self::arithmetic::mul_floats));
 
-    env.set_function("/", self::arithmetic::div_ints);
-    env.set_function("/.", self::arithmetic::div_floats);
+    env.insert_here("/", free_fn("/", self::arithmetic::div_ints));
+    env.insert_here("/.", free_fn("/.", self::arithmetic::div_floats));
 }
 
 pub fn load_math(env: &Env) {
     let mut env = env.borrow_mut();
-    env.set_function("nan?", self::math::is_nan);
-    env.set_function("infinite?", self::math::is_infinite);
-    env.set_function("finite?", self::math::is_finite);
-    env.set_function("normal?", self::math::is_normal);
+    env.insert_here("nan?", free_fn("nan?", self::math::is_nan));
+    env.insert_here("infinite?", free_fn("infinite?", self::math::is_infinite));
+    env.insert_here("finite?", free_fn("finite?", self::math::is_finite));
+    env.insert_here("normal?", free_fn("normal?", self::math::is_normal));
 
-    env.set_function("floor", self::math::floor);
-    env.set_function("ceil", self::math::ceil);
-    env.set_function("round", self::math::round);
-    env.set_function("trunc", self::math::trunc);
+    env.insert_here("floor", free_fn("floor", self::math::floor));
+    env.insert_here("ceil", free_fn("ceil", self::math::ceil));
+    env.insert_here("round", free_fn("round", self::math::round));
+    env.insert_here("trunc", free_fn("trunc", self::math::trunc));
 
-    env.set_function("fract", self::math::fract);
-    env.set_function("sign_positive?", self::math::is_sign_positive);
-    env.set_function("sign_negative?", self::math::is_sign_negative);
-    env.set_function("recip", self::math::recip);
-    env.set_function("sqrt", self::math::sqrt);
-    env.set_function("exp", self::math::exp);
-    env.set_function("exp2", self::math::exp2);
-    env.set_function("ln", self::math::ln);
-    env.set_function("log2", self::math::log2);
-    env.set_function("log10", self::math::log10);
-    env.set_function("->degrees", self::math::to_degrees);
-    env.set_function("->radians", self::math::to_radians);
-    env.set_function("cbrt", self::math::cbrt);
-    env.set_function("sin", self::math::sin);
-    env.set_function("cos", self::math::cos);
-    env.set_function("tan", self::math::tan);
-    env.set_function("asin", self::math::asin);
-    env.set_function("acos", self::math::acos);
-    env.set_function("atan", self::math::atan);
-    env.set_function("exp_m1", self::math::exp_m1);
-    env.set_function("ln_1p", self::math::ln_1p);
-    env.set_function("sinh", self::math::sinh);
-    env.set_function("cosh", self::math::cosh);
-    env.set_function("tanh", self::math::tanh);
-    env.set_function("asinh", self::math::asinh);
-    env.set_function("acosh", self::math::acosh);
-    env.set_function("atanh", self::math::atanh);
+    env.insert_here("fract", free_fn("fract", self::math::fract));
+    env.insert_here("sign_positive?", free_fn("sign_positive?", self::math::is_sign_positive));
+    env.insert_here("sign_negative?", free_fn("sign_negative?", self::math::is_sign_negative));
+    env.insert_here("recip", free_fn("recip", self::math::recip));
+    env.insert_here("sqrt", free_fn("sqrt", self::math::sqrt));
+    env.insert_here("exp", free_fn("exp", self::math::exp));
+    env.insert_here("exp2", free_fn("exp2", self::math::exp2));
+    env.insert_here("ln", free_fn("ln", self::math::ln));
+    env.insert_here("log2", free_fn("log2", self::math::log2));
+    env.insert_here("log10", free_fn("log10", self::math::log10));
+    env.insert_here("->degrees", free_fn("->degrees", self::math::to_degrees));
+    env.insert_here("->radians", free_fn("->radians", self::math::to_radians));
+    env.insert_here("cbrt", free_fn("cbrt", self::math::cbrt));
+    env.insert_here("sin", free_fn("sin", self::math::sin));
+    env.insert_here("cos", free_fn("cos", self::math::cos));
+    env.insert_here("tan", free_fn("tan", self::math::tan));
+    env.insert_here("asin", free_fn("asin", self::math::asin));
+    env.insert_here("acos", free_fn("acos", self::math::acos));
+    env.insert_here("atan", free_fn("atan", self::math::atan));
+    env.insert_here("exp_m1", free_fn("exp_m1", self::math::exp_m1));
+    env.insert_here("ln_1p", free_fn("ln_1p", self::math::ln_1p));
+    env.insert_here("sinh", free_fn("sinh", self::math::sinh));
+    env.insert_here("cosh", free_fn("cosh", self::math::cosh));
+    env.insert_here("tanh", free_fn("tanh", self::math::tanh));
+    env.insert_here("asinh", free_fn("asinh", self::math::asinh));
+    env.insert_here("acosh", free_fn("acosh", self::math::acosh));
+    env.insert_here("atanh", free_fn("atanh", self::math::atanh));
 
-    env.set_function("count_ones", self::math::count_ones);
-    env.set_function("count_zeros", self::math::count_zeros);
-    env.set_function("leading_zeros", self::math::leading_zeros);
-    env.set_function("trailing_zeros", self::math::trailing_zeros);
-    env.set_function("swap_bytes", self::math::swap_bytes);
-    env.set_function("->big-endian", self::math::to_be);
-    env.set_function("->little-endian", self::math::to_le);
-    env.set_function("abs", self::math::abs);
-    env.set_function("signum", self::math::signum);
-    env.set_function("positive?", self::math::is_positive);
-    env.set_function("negative?", self::math::is_negative);
+    env.insert_here("count_ones", free_fn("count_ones", self::math::count_ones));
+    env.insert_here("count_zeros", free_fn("count_zeros", self::math::count_zeros));
+    env.insert_here("leading_zeros", free_fn("leading_zeros", self::math::leading_zeros));
+    env.insert_here("trailing_zeros", free_fn("trailing_zeros", self::math::trailing_zeros));
+    env.insert_here("swap_bytes", free_fn("swap_bytes", self::math::swap_bytes));
+    env.insert_here("->big-endian", free_fn("->big-endian", self::math::to_be));
+    env.insert_here("->little-endian", free_fn("->little-endian", self::math::to_le));
+    env.insert_here("abs", free_fn("abs", self::math::abs));
+    env.insert_here("signum", free_fn("signum", self::math::signum));
+    env.insert_here("positive?", free_fn("positive?", self::math::is_positive));
+    env.insert_here("negative?", free_fn("negative?", self::math::is_negative));
 }
 
 pub fn load_types(env: &Env) {
     let mut env = env.borrow_mut();
-    env.set_function("->int", self::types::to_int);
-    env.set_function("->float", self::types::to_float);
-    env.set_function("->string", self::types::to_string);
-    env.set_function("->bool", self::types::to_bool);
+    env.insert_here("->int", free_fn("->int", self::types::to_int));
+    env.insert_here("->float", free_fn("->float", self::types::to_float));
+    env.insert_here("->string", free_fn("->string", self::types::to_string));
+    env.insert_here("->bool", free_fn("->bool", self::types::to_bool));
 
-    env.set_function("int?", self::types::is_int);
-    env.set_function("float?", self::types::is_float);
-    env.set_function("bool?", self::types::is_bool);
-    env.set_function("string?", self::types::is_string);
-    env.set_function("list?", self::types::is_list);
-    env.set_function("lambda?", self::types::is_lambda);
-    env.set_function("foreign-fn?", self::types::is_foreign_fn);
-    env.set_function("executable", self::types::is_executable);
+    env.insert_here("int?", free_fn("int?", self::types::is_int));
+    env.insert_here("float?", free_fn("float?", self::types::is_float));
+    env.insert_here("bool?", free_fn("bool?", self::types::is_bool));
+    env.insert_here("string?", free_fn("string?", self::types::is_string));
+    env.insert_here("list?", free_fn("list?", self::types::is_list));
+    env.insert_here("lambda?", free_fn("lambda?", self::types::is_lambda));
+    env.insert_here("foreign-fn?", free_fn("foreign-fn?", self::types::is_foreign_fn));
+    env.insert_here("executable", free_fn("executable", self::types::is_executable));
 }

--- a/src/stdlib/types.rs
+++ b/src/stdlib/types.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 use ::{Value, AresResult, AresError, rc_to_usize};
-use super::util::{no_more_or_arity_err, unwrap_or_arity_err};
+use super::util::expect_arity;
 
 macro_rules! gen_is_type {
     ($name: ident, $p: ident) => {
@@ -41,70 +41,71 @@ pub fn is_executable(values: &[Value]) -> AresResult<Value> {
 
 
 pub fn to_int(values: &[Value]) -> AresResult<Value> {
-    let mut values = values.iter();
-     let res = match try!(unwrap_or_arity_err(values.next(), 0, "exactly 1")) {
-         &Value::Int(i) => Ok(Value::Int(i)),
-         &Value::Float(f) => Ok(Value::Int(f as i64)),
-         &Value::Bool(b) => Ok(Value::Int(if b {1} else {0})),
-         &Value::String(ref s) => Ok(Value::Int(s.parse().unwrap())),
-         other => Err(AresError::IllegalConversion {
-             value: other.clone(),
-             into: "Int".to_string()
-         })
-     };
-     try!(no_more_or_arity_err(&mut values, 1, "exactly 1"));
-     res
+    try!(expect_arity(values, |l| l == 1, "exactly 1"));
+
+    let res = match values.first().unwrap() {
+        &Value::Int(i) => Ok(Value::Int(i)),
+        &Value::Float(f) => Ok(Value::Int(f as i64)),
+        &Value::Bool(b) => Ok(Value::Int(if b {1} else {0})),
+        &Value::String(ref s) => Ok(Value::Int(s.parse().unwrap())),
+        other => Err(AresError::IllegalConversion {
+            value: other.clone(),
+            into: "Int".to_string()
+        })
+    };
+
+    res
 }
 
 pub fn to_float(values: &[Value]) -> AresResult<Value> {
-    let mut values = values.iter();
-     let res = match try!(unwrap_or_arity_err(values.next(), 0, "exactly 1")){
-         &Value::Int(i) => Ok(Value::Float(i as f64)),
-         &Value::Float(f) => Ok(Value::Float(f)),
-         &Value::String(ref s) => Ok(Value::Float(s.parse().unwrap())),
-         other => Err(AresError::IllegalConversion {
-             value: other.clone(),
-             into: "Float".to_string()
-         })
-     };
-     try!(no_more_or_arity_err(&mut values, 1, "exactly 1"));
-     res
+    try!(expect_arity(values, |l| l == 1, "exactly 1"));
+
+    let res = match values.first().unwrap() {
+        &Value::Int(i) => Ok(Value::Float(i as f64)),
+        &Value::Float(f) => Ok(Value::Float(f)),
+        &Value::String(ref s) => Ok(Value::Float(s.parse().unwrap())),
+        other => Err(AresError::IllegalConversion {
+            value: other.clone(),
+            into: "Float".to_string()
+        })
+    };
+    res
 }
 
 pub fn to_bool(values: &[Value]) -> AresResult<Value> {
-    let mut values = values.iter();
-     let res = match try!(unwrap_or_arity_err(values.next(), 0, "exactly 1")) {
-         &Value::Int(0) => Ok(Value::Bool(false)),
-         &Value::Int(_) => Ok(Value::Bool(true)),
-         &Value::Float(0.0) => Ok(Value::Bool(false)),
-         // TODO: Float(nan) => Ok(false)?
-         &Value::Float(_) => Ok(Value::Bool(true)),
-         &Value::Bool(b) => Ok(Value::Bool(b)),
-         &Value::String(ref s) => {
-             if &**s == "true" {
-                 Ok(Value::Bool(true))
-             } else if &**s == "false" {
-                 Ok(Value::Bool(false))
-             } else {
-                 Err(AresError::IllegalConversion{
-                     value: Value::String(s.clone()),
-                     into: "Bool".to_string()
-                 })
-             }
-         }
-         other => Err(AresError::IllegalConversion {
-             value: other.clone(),
-             into: "Bool".to_string()
-         })
-     };
-     try!(no_more_or_arity_err(&mut values, 1, "exactly 1"));
-     res
+    try!(expect_arity(values, |l| l == 1, "exactly 1"));
+
+    let res = match values.first().unwrap() {
+        &Value::Int(0) => Ok(Value::Bool(false)),
+        &Value::Int(_) => Ok(Value::Bool(true)),
+        &Value::Float(0.0) => Ok(Value::Bool(false)),
+        // TODO: Float(nan) => Ok(false)?
+        &Value::Float(_) => Ok(Value::Bool(true)),
+        &Value::Bool(b) => Ok(Value::Bool(b)),
+        &Value::String(ref s) => {
+            if &**s == "true" {
+                Ok(Value::Bool(true))
+            } else if &**s == "false" {
+                Ok(Value::Bool(false))
+            } else {
+                Err(AresError::IllegalConversion{
+                    value: Value::String(s.clone()),
+                    into: "Bool".to_string()
+                })
+            }
+        }
+        other => Err(AresError::IllegalConversion {
+            value: other.clone(),
+            into: "Bool".to_string()
+        })
+    };
+
+    res
 }
 
 pub fn to_string(values: &[Value]) -> AresResult<Value> {
-    let mut values = values.iter();
-    let first = try!(unwrap_or_arity_err(values.next(), 0, "exactly 1"));
-    try!(no_more_or_arity_err(&mut values, 1, "exactly 1"));
+    try!(expect_arity(values, |l| l == 1, "exactly 1"));
+    let first = values.first().unwrap();
     let s = to_string_helper(&first);
     Ok(Value::String(Rc::new(s)))
 }


### PR DESCRIPTION
This is a pretty big change to how FFI functions work.  Instead of having two different kinds of foreign functions FreeFunction and UnevalFunction, this work unifies them into one.  

This "one" function type has the same signature as the previous UnevalFunction.  However for utility, it takes a slice of values rather than an iterator.  (it turns out that the perf benefit from using an iterator was non existent). 

However, functions that used to be "free functions" are still usable by passing them through the `free_fn` function.  This works by boxing up a closure that evaluates the arguments and gives them to the passed-in function.

Functions that used to be called UnevalFunctions are now called `ast_fn` in order to make it obvious that you are operating on an AST, not actual values.

In the future, I have plans for more function types.

TODO: most of the standard library code was written using iterators, and it looks really bad now...  Tests pass by turning the slices into iterators (like they were before), but the code looks really ugly. 