### PR TITLE
Symbol Interning Implementation

### DIFF
--- a/examples/runscript.rs
+++ b/examples/runscript.rs
@@ -1,0 +1,23 @@
+extern crate ares;
+
+use ares::{Value, Context, free_fn};
+use std::io::{Read, stdin};
+use std::fmt::Write;
+
+fn main() {
+    let mut ctx = Context::new().with_debug();
+    ctx.set_fn("print", free_fn("print", |args| {
+        let mut buf = String::new();
+        write!(buf, "{:?}", args);
+        println!("{}", buf);
+        Ok(Value::string(buf))
+    }));
+
+    let mut dummy = ();
+    let mut ctx = ctx.load(&mut dummy);
+
+    let mut buffer = String::new();
+    stdin().read_to_string(&mut buffer);
+
+    ctx.eval_str(&buffer);
+}

--- a/examples/runscript.rs
+++ b/examples/runscript.rs
@@ -6,6 +6,7 @@ use std::fmt::Write;
 
 fn main() {
     let mut ctx = Context::new().with_debug();
+
     ctx.set_fn("print", free_fn("print", |args| {
         let mut buf = String::new();
         write!(buf, "{:?}", args);

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -12,10 +12,10 @@ mod context;
 
 pub fn eval<S: State + ?Sized>(value: &Value, ctx: &mut LoadedContext<S>) -> AresResult<Value> {
     match value {
-        &Value::Symbol(ref symbol) => {
-            match ctx.env().borrow().get(&symbol) {
+        &Value::Symbol(symbol) => {
+            match ctx.env().borrow().get(symbol) {
                 Some(v) => Ok(v),
-                None => Err(AresError::UndefinedName((**symbol).clone()))
+                None => Err(AresError::UndefinedName(ctx.interner().lookup_or_unknown(symbol).into()))
             }
         },
 

--- a/src/eval/procedure.rs
+++ b/src/eval/procedure.rs
@@ -4,11 +4,12 @@ use std::collections::HashMap;
 use ::{Value, rc_to_usize, write_usize};
 
 pub use super::environment::{Env, Environment};
+use ::intern::Symbol;
 
 #[derive(Clone, Eq, PartialEq)]
 pub enum ParamBinding {
-    SingleIdent(String),
-    ParamList(Vec<String>)
+    SingleIdent(Symbol),
+    ParamList(Vec<Symbol>)
 }
 
 #[derive(Clone)]

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash)]
 pub struct Symbol {
     id: u32
 }
@@ -38,8 +38,20 @@ impl SymbolIntern {
         }
     }
 
-    pub fn lookup(&self, symbol: &Symbol) -> Option<&str> {
-        self.sym_to_string.get(symbol).map(|s| &s[..])
+    pub fn symbol_for_name<S: AsRef<str>>(&self, symbol_str: &S) -> Option<Symbol> {
+        self.string_to_sym.get(symbol_str.as_ref()).cloned()
+    }
+
+    pub fn contains<S: AsRef<str>>(&self, symbol_str: S) -> bool {
+        self.string_to_sym.contains_key(symbol_str.as_ref())
+    }
+
+    pub fn lookup(&self, symbol: Symbol) -> Option<&str> {
+        self.sym_to_string.get(&symbol).map(|s| &s[..])
+    }
+
+    pub fn lookup_or_unknown(&self, symbol: Symbol) -> &str {
+        self.lookup(symbol).unwrap_or("<unknown symbol>")
     }
 }
 

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash)]
+pub struct Symbol {
+    id: u32
+}
+
+pub struct SymbolIntern {
+    current_id: u32,
+    sym_to_string: HashMap<Symbol, String>,
+    string_to_sym: HashMap<String, Symbol>,
+}
+
+impl SymbolIntern {
+    pub fn new() -> SymbolIntern {
+        SymbolIntern {
+            current_id: 0,
+            sym_to_string: HashMap::new(),
+            string_to_sym: HashMap::new(),
+        }
+    }
+
+    pub fn gen_sym(&mut self) -> Symbol {
+        let ret = Symbol { id: self.current_id };
+        self.current_id += 1;
+        ret
+    }
+
+    pub fn intern<S: AsRef<str> + Into<String>>(&mut self, symbol_str: S) -> Symbol {
+        if self.string_to_sym.contains_key(symbol_str.as_ref()) {
+            self.string_to_sym[symbol_str.as_ref()]
+        } else {
+            let symbol_str = symbol_str.into();
+            let symbol = self.gen_sym();
+            self.sym_to_string.insert(symbol, symbol_str.clone());
+            self.string_to_sym.insert(symbol_str, symbol);
+            symbol
+        }
+    }
+
+    pub fn lookup(&self, symbol: &Symbol) -> Option<&str> {
+        self.sym_to_string.get(symbol).map(|s| &s[..])
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub enum Value {
     Bool(bool),
     Map(Rc<HashMap<Value, Value>>),
 
-    Symbol(Rc<String>),
+    Symbol(intern::Symbol),
     ForeignFn(ForeignFunction<()>),
     Lambda(Procedure),
 
@@ -57,10 +57,6 @@ pub enum Value {
 impl Value {
     pub fn string<S: Into<String>>(s: S) -> Value {
         Value::String(Rc::new(s.into()))
-    }
-
-    pub fn symbol<S: Into<String>>(s: S) -> Value {
-        Value::Symbol(Rc::new(s.into()))
     }
 
     pub fn list(v: Vec<Value>) -> Value {
@@ -119,8 +115,7 @@ impl PartialEq for Value {
             (&Float(f1), &Float(f2)) => f1 == f2,
             (&Int(i1), &Int(i2)) => i1 == i2,
             (&Bool(b1), &Bool(b2)) => b1 == b2,
-            (&Symbol(ref id1), &Symbol(ref id2)) =>
-                rc_to_usize(id1) == rc_to_usize(id2) || id1 == id2,
+            (&Symbol(ref id1), &Symbol(ref id2)) => id1 == id2,
             (&ForeignFn(ref ff1), &ForeignFn(ref ff2)) => ff1 == ff2,
             (&Lambda(ref l1), &Lambda(ref l2)) => l1 == l2,
             (&Map(ref m1), &Map(ref m2)) => m1 == m2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod eval;
 pub mod stdlib;
 mod error;
 pub mod util;
+pub mod intern;
 
 pub use parse::parse;
 pub use eval::{

--- a/src/parse/util.rs
+++ b/src/parse/util.rs
@@ -1,10 +1,12 @@
 use super::super::Value;
 use super::super::Value::*;
+use ::intern::SymbolIntern;
 
-pub fn immediate_value(v: &Value) -> bool {
+pub fn immediate_value(v: &Value, interner: &mut SymbolIntern) -> bool {
     match v {
-        &Map(ref m) => m.iter().all(|(k, v)| immediate_value(k) && immediate_value(v)),
-        &List(ref vec) => vec.len() == 2 && vec[0] == Value::symbol("quote"),
+        &Map(ref m) => m.iter().all(|(k, v)| immediate_value(k, interner) &&
+                                             immediate_value(v, interner)),
+        &List(ref vec) => vec.len() == 2 && vec[0] == Value::Symbol(interner.intern("quote")),
         &Symbol(_) => false,
         _ => true
     }
@@ -17,10 +19,10 @@ pub fn unquote(v: Value) -> Value {
     }
 }
 
-pub fn can_be_hash_key(v: &Value) -> bool {
+pub fn can_be_hash_key(v: &Value, interner: &mut SymbolIntern) -> bool {
     match v {
         &Map(..) | &Symbol(..) => false,
-        &List(ref vec) => vec.len() == 2 && vec[0] == Value::symbol("quote") && match &vec[1] {
+        &List(ref vec) => vec.len() == 2 && vec[0] == Value::Symbol(interner.intern("quote")) && match &vec[1] {
             &Map(..) | &List(..) => false,
             _ => true
         },

--- a/src/stdlib/debugger.rs
+++ b/src/stdlib/debugger.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::cell::RefCell;
 use ::{Value, AresResult, LoadedContext, State, user_fn, free_fn, Environment};
 use ::util::prompt;
+use ::intern::Symbol;
 use super::util::expect_arity;
 
 pub fn debugger<S: State + ?Sized>(args: &[Value], ctx: &mut LoadedContext<S>) -> AresResult<Value> {
@@ -19,7 +20,7 @@ pub fn debugger<S: State + ?Sized>(args: &[Value], ctx: &mut LoadedContext<S>) -
 
     let debugger_env = move |values: &[Value], ctx: &mut LoadedContext<S>| -> AresResult<Value> {
         try!(expect_arity(values, |l| l == 0, "exactly 0"));
-        let mut list: Vec<(String, (u32, Value))> = ctx.env().borrow().all_defined().into_iter().collect();
+        let mut list: Vec<(Symbol, (u32, Value))> = ctx.env().borrow().all_defined().into_iter().collect();
         // Invert the sort
         list.sort_by(|a, b| (b.1).0.cmp(&(a.1).0));
 
@@ -30,7 +31,7 @@ pub fn debugger<S: State + ?Sized>(args: &[Value], ctx: &mut LoadedContext<S>) -
                 last_level = level;
             }
 
-            println!("{}: {:?}", name, value);
+            println!("{}: {:?}", ctx.interner().lookup_or_unknown(name), value);
         }
         Ok(false.into())
     };
@@ -38,8 +39,8 @@ pub fn debugger<S: State + ?Sized>(args: &[Value], ctx: &mut LoadedContext<S>) -
     let debugger_close: Value = Value::ForeignFn(free_fn::<S, _, _>("debugger-close", debugger_close).erase());
     let debugger_env: Value = Value::ForeignFn(user_fn::<S, _, _>("debugger-env", debugger_env).erase());
     let mut mapping = HashMap::new();
-    mapping.insert("debugger-close".to_owned(), debugger_close);
-    mapping.insert("debugger-env".to_owned(), debugger_env);
+    mapping.insert(ctx.interner_mut().intern("debugger-close"), debugger_close);
+    mapping.insert(ctx.interner_mut().intern("debugger-env"), debugger_env);
     let mut new_env = Environment::new_with_data(ctx.env().clone(), mapping);
 
     ctx.with_other_env(&mut new_env, |ctx| {

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -1,5 +1,10 @@
 use ::{user_fn, free_fn, ast_fn, Context, State};
 
+// Keep these here for when you want to build huge changes
+// pub fn load_all<T>(_: T) {}
+// pub fn load_debug<T>(_: T) {}
+
+
 pub mod arithmetic;
 pub mod math;
 pub mod core;
@@ -156,7 +161,7 @@ pub fn load_math<S: State + ?Sized>(ctx: &mut Context<S>) {
 pub fn load_types<S: State + ?Sized>(ctx: &mut Context<S>) {
     ctx.set_fn("->int", free_fn("->int", self::types::to_int));
     ctx.set_fn("->float", free_fn("->float", self::types::to_float));
-    ctx.set_fn("->string", free_fn("->string", self::types::to_string));
+    ctx.set_fn("->string", ast_fn("->string", self::types::to_string));
     ctx.set_fn("->bool", free_fn("->bool", self::types::to_bool));
 
     ctx.set_fn("int?", free_fn("int?", self::types::is_int));


### PR DESCRIPTION
All symbols should be interned during parse-time.  Additionally, a `(gen-sym)` function could be added to the lisp environment.