### PR TITLE
Add with_other_state to loadedcontext

### DIFF
--- a/src/eval/context.rs
+++ b/src/eval/context.rs
@@ -104,6 +104,17 @@ impl <'a, S: State + ?Sized> LoadedContext<'a, S> {
         r
     }
 
+    pub fn with_other_state<F, R>(&mut self, state: &mut S, f: F) -> R
+    where F: FnOnce(&mut LoadedContext<'a, S>) -> R {
+        use std::mem::{swap, transmute};
+        // This is safe because the state gets immeditately swapped back out.
+        let mut state: &'a mut S = unsafe { transmute(state) };
+        swap(&mut self.state, &mut state);
+        let r = f(self);
+        swap(&mut self.state, &mut state);
+        r
+    }
+
     pub fn state(&mut self) -> &mut S {
         self.state
     }

--- a/tests/with_other_state.rs
+++ b/tests/with_other_state.rs
@@ -1,0 +1,24 @@
+extern crate ares;
+use ares::*;
+
+#[test]
+fn basic_swap() {
+    let mut context = Context::new();
+    context.set_fn("run", user_fn("run", |_args, ctx| {
+        *ctx.state() = *ctx.state() + 1;
+        Ok(Value::Int(*ctx.state()))
+   }));
+
+    let mut outer = 0i64;
+    let mut inner = 0i64;
+    {
+        let mut loaded = context.load(&mut outer);
+        assert_eq!(loaded.eval_str("(run)").unwrap(), 1.into());
+
+        loaded.with_other_state(&mut inner, |new_loaded| {
+            assert_eq!(new_loaded.eval_str("(run)").unwrap(), 1.into());
+        });
+    }
+    assert_eq!(outer, 1);
+    assert_eq!(inner, 1);
+}


### PR DESCRIPTION
This will let people swap the state out of an already loaded context.

This can be useful while inside of User Functions or Ast Functions.  

```rust
let mut ctx = Context::new();
ctx.set_fn("something", ast_fn("something", |args, ctx| {
    let mut new_state = 0;
    ctx.with_other_state(&mut new_state, move |new_ctx| {
        for expr in args {
            new_ctx.eval(&expr);
        }
    }
}));
```